### PR TITLE
Fix PodCreate example indentation

### DIFF
--- a/src/main/java/io/kestra/plugin/kubernetes/PodCreate.java
+++ b/src/main/java/io/kestra/plugin/kubernetes/PodCreate.java
@@ -69,7 +69,7 @@ import static io.kestra.plugin.kubernetes.services.PodService.waitForCompletion;
                           - 'bash'
                           - '-c'
                           - 'for i in {1..10}; do echo $i; sleep 0.1; done'
-                    restartPolicy: Never
+                      restartPolicy: Never
                 """
         ),
         @Example(


### PR DESCRIPTION
When using the PodCreate example of the kubernetes plugin, I had an indentation error on the spec of the pod. This PR fixes it