### PR TITLE
fix(kubernetes): default apiGroup should be empty

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ out/
 .classpath
 .attach*
 src/test/resources/application-test.yml
+kind
+kubectl

--- a/src/main/java/io/kestra/plugin/kubernetes/kubectl/Apply.java
+++ b/src/main/java/io/kestra/plugin/kubernetes/kubectl/Apply.java
@@ -57,6 +57,63 @@ import java.util.List;
                     namespace: default
                     spec: "{{ read('deployment.yaml') }}"
                 """
+        ),
+        @Example(
+            title = "Apply a Kubernetes custom resource definition, using YAML.",
+            full = true,
+            code = """
+                id: k8s
+                namespace: company.name
+
+                tasks:
+                  - id: apply
+                    type: io.kestra.plugin.kubernetes.kubectl.Apply
+                    namespace: default
+                    spec: |-
+                      apiVersion: apiextensions.k8s.io/v1
+                      kind: CustomResourceDefinition
+                      metadata:
+                        name: shirts.stable.example.com
+                      spec:
+                        group: stable.example.com
+                        scope: Namespaced
+                        names:
+                          plural: shirts
+                          singular: shirt
+                          kind: Shirt
+                        versions:
+                        - name: v1
+                          served: true
+                          storage: true
+                          schema:
+                            openAPIV3Schema:
+                              type: object
+                              properties:
+                                apiVersion:
+                                  type: string
+                                kind:
+                                  type: string
+                                metadata:
+                                  type: object
+                                spec:
+                                  type: object
+                                  x-kubernetes-preserve-unknown-fields: true # Allows any fields in spec
+                                  properties:
+                                    # You should define your actual Shirt properties here later
+                                    # For example:
+                                    # color:
+                                    #   type: string
+                                    # size:
+                                    #   type: string
+                                    #   enum: ["S", "M", "L", "XL"]
+                                status:
+                                  type: object
+                                  x-kubernetes-preserve-unknown-fields: true # Allows any fields in status
+                                  properties:
+                                    # Define your status properties here
+                                    # message:
+                                    #   type: string
+                """
         )
     }
 )

--- a/src/main/java/io/kestra/plugin/kubernetes/kubectl/Delete.java
+++ b/src/main/java/io/kestra/plugin/kubernetes/kubectl/Delete.java
@@ -69,6 +69,16 @@ public class Delete extends AbstractPod implements RunnableTask<VoidOutput> {
     @NotNull
     private Property<List<String>> resourcesNames;
 
+    @Schema(
+        title = "The Kubernetes resource apiGroup"
+    )
+    private Property<String> apiGroup;
+
+    @Schema(
+        title = "The Kubernetes resource apiVersion"
+    )
+    private Property<String> apiVersion;
+
     @Override
     public VoidOutput run(RunContext runContext) throws Exception {
 
@@ -79,12 +89,14 @@ public class Delete extends AbstractPod implements RunnableTask<VoidOutput> {
             var renderedKind = runContext.render(this.resourceType).as(String.class)
                 .orElseThrow(() -> new IllegalArgumentException("resourceType must be provided and rendered."));
             var renderedResourcesNames = runContext.render(this.resourcesNames).asList(String.class);
+            var renderedApiGroup = runContext.render(this.apiGroup).as(String.class).orElse("");
+            var renderedApiVersion = runContext.render(this.apiVersion).as(String.class).orElse("v1");
 
             runContext.logger().debug("Deleting resource(s) '{}' of kind '{}' in namespace '{}'", renderedResourcesNames, renderedKind, renderedNamespace);
 
             var resourceDefinitionContext = new ResourceDefinitionContext.Builder()
-                .withGroup("apps")
-                .withVersion("v1")
+                .withGroup(renderedApiGroup)
+                .withVersion(renderedApiVersion)
                 .withKind(renderedKind)
                 .withNamespaced(true) // Assuming resources are namespaced as we take namespace input
                 .build();

--- a/src/main/java/io/kestra/plugin/kubernetes/kubectl/Get.java
+++ b/src/main/java/io/kestra/plugin/kubernetes/kubectl/Get.java
@@ -152,7 +152,7 @@ public class Get extends AbstractPod implements RunnableTask<Get.Output> {
         var renderedResourceType = runContext.render(this.resourceType).as(String.class)
             .orElseThrow(() -> new IllegalArgumentException("resourceType must be provided and rendered."));
         var renderedResourcesNames = runContext.render(this.resourcesNames).asList(String.class);
-        var renderedApiGroup = runContext.render(this.apiGroup).as(String.class).orElse("apps");
+        var renderedApiGroup = runContext.render(this.apiGroup).as(String.class).orElse("");
         var renderedApiVersion = runContext.render(this.apiVersion).as(String.class).orElse("v1");
         var renderedFetchType = runContext.render(this.fetchType).as(FetchType.class).orElse(NONE);
 
@@ -161,6 +161,7 @@ public class Get extends AbstractPod implements RunnableTask<Get.Output> {
         try (var client = PodService.client(runContext, this.getConnection())) {
 
             var resourceDefinitionContext = new ResourceDefinitionContext.Builder()
+                // See: https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-uris
                 .withGroup(renderedApiGroup)
                 .withVersion(renderedApiVersion)
                 .withKind(renderedResourceType)

--- a/src/test/java/io/kestra/plugin/kubernetes/kubectl/ApplyTest.java
+++ b/src/test/java/io/kestra/plugin/kubernetes/kubectl/ApplyTest.java
@@ -2,7 +2,6 @@ package io.kestra.plugin.kubernetes.kubectl;
 
 import io.kestra.core.junit.annotations.KestraTest;
 import io.kestra.core.models.property.Property;
-import io.kestra.core.runners.RunContext;
 import io.kestra.core.runners.RunContextFactory;
 import jakarta.inject.Inject;
 import lombok.extern.slf4j.Slf4j;

--- a/src/test/java/io/kestra/plugin/kubernetes/kubectl/DeleteTest.java
+++ b/src/test/java/io/kestra/plugin/kubernetes/kubectl/DeleteTest.java
@@ -67,6 +67,8 @@ public class DeleteTest {
             .namespace(Property.ofValue(DEFAULT_NAMESPACE))
             .resourceType(Property.ofValue("deployments"))
             .resourcesNames(Property.ofValue(List.of("my-deployment")))
+            .apiGroup(Property.ofValue("apps"))
+            .apiVersion(Property.ofValue("v1"))
             .fetchType(Property.ofValue(FetchType.FETCH_ONE))
             .build();
 
@@ -82,6 +84,8 @@ public class DeleteTest {
             .namespace(Property.ofValue(DEFAULT_NAMESPACE))
             .resourceType(Property.ofValue("deployments"))
             .resourcesNames(Property.ofValue(List.of("my-deployment")))
+            .apiGroup(Property.ofValue("apps"))
+            .apiVersion(Property.ofValue("v1"))
             .build();
 
         // Then
@@ -147,6 +151,8 @@ public class DeleteTest {
             .type(Get.class.getName())
             .namespace(Property.ofValue(DEFAULT_NAMESPACE))
             .resourceType(Property.ofValue("deployments"))
+            .apiGroup(Property.ofValue("apps"))
+            .apiVersion(Property.ofValue("v1"))
             .fetchType(Property.ofValue(FetchType.FETCH))
             .build();
 
@@ -162,6 +168,8 @@ public class DeleteTest {
             .namespace(Property.ofValue(DEFAULT_NAMESPACE))
             .resourceType(Property.ofValue("deployments"))
             .resourcesNames(Property.ofValue(deploymentsNames))
+            .apiGroup(Property.ofValue("apps"))
+            .apiVersion(Property.ofValue("v1"))
             .build();
 
         // Then

--- a/src/test/java/io/kestra/plugin/kubernetes/kubectl/GetTest.java
+++ b/src/test/java/io/kestra/plugin/kubernetes/kubectl/GetTest.java
@@ -74,6 +74,8 @@ public class GetTest {
             .namespace(Property.ofValue(DEFAULT_NAMESPACE))
             .resourceType(Property.ofValue("deployments"))
             .resourcesNames(Property.ofValue(List.of(expectedDeploymentName)))
+            .apiGroup(Property.ofValue("apps"))
+            .apiVersion(Property.ofValue("v1"))
             .fetchType(Property.ofValue(FetchType.FETCH_ONE))
             .build();
 
@@ -138,6 +140,8 @@ public class GetTest {
             .type(Get.class.getName())
             .namespace(Property.ofValue(DEFAULT_NAMESPACE))
             .resourceType(Property.ofValue("deployments"))
+            .apiGroup(Property.ofValue("apps"))
+            .apiVersion(Property.ofValue("v1"))
             .fetchType(Property.ofValue(FetchType.FETCH))
             .build();
 
@@ -230,9 +234,9 @@ public class GetTest {
             .type(Get.class.getName())
             .namespace(Property.ofValue(DEFAULT_NAMESPACE))
             .resourceType(Property.ofValue(shirtKind))
-            .fetchType(Property.ofValue(FetchType.FETCH_ONE))
             .apiGroup(Property.ofValue(apiGroup))
             .apiVersion(Property.ofValue(apiVersion))
+            .fetchType(Property.ofValue(FetchType.FETCH_ONE))
             .build();
 
 


### PR DESCRIPTION
The idea is too avoid having "apps" as a default api group because for Kubernetes basic resources there's no api group so the call where ending in `/apis/apps/api/v1` instead of `/api/v1` in Fabric8 client.

<!-- Thanks for submitting a Pull Request to kestra. To help us review your contribution, please follow the guidelines below:

- Make sure that your commits follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) specification e.g. `feat(ui): add a new navigation menu item` or `fix(core): fix a bug in the core model` or `docs: update the README.md`. This will help us automatically generate the changelog.
- The title should briefly summarize the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share a flow example to help the reviewer understand and QA the change.
- Use "close" to automatically close an issue. For example, `close #1234` will close issue #1234. -->

### What changes are being made and why?
<!-- Please include a brief summary of the changes included in this PR e.g. closes #1234. -->

---

### How the changes have been QAed?

<!-- Include example code that shows how this PR has been QAed. The code should present a complete yet easily reproducible flow.

```yaml
# Your example flow code here
```

Note that this is not a replacement for unit tests but rather a way to demonstrate how the changes work in a real-life scenario, as the end-user would experience them.

Remove this section if this change applies to all flows or to the documentation only. -->

---

### Setup Instructions

<!--If there are any setup requirements like API keys or trial accounts, kindly include brief bullet-points-description outlining the setup process below.

- [External System Documentation](URL)
- Steps to set up the necessary resources

If there are no setup requirements, you can remove this section.

Thank you for your contribution. ❤️  -->

closes #182 