### PR TITLE
feat: extend file sidecar to allow setting resource requirements

### DIFF
--- a/src/main/java/io/kestra/plugin/kubernetes/AbstractPod.java
+++ b/src/main/java/io/kestra/plugin/kubernetes/AbstractPod.java
@@ -179,6 +179,7 @@ abstract public class AbstractPod extends AbstractConnection {
         ContainerBuilder containerBuilder = new ContainerBuilder()
             .withName(finished ? SIDECAR_FILES_CONTAINER_NAME : INIT_FILES_CONTAINER_NAME)
             .withImage(fileSidecar != null ? runContext.render(fileSidecar.getImage()).as(String.class).orElse("busybox") : "busybox")
+            .withResources(fileSidecar != null ? fileSidecar.getResources() : null)
             .withCommand(Arrays.asList(
                 "sh",
                 "-c",

--- a/src/main/java/io/kestra/plugin/kubernetes/AbstractPod.java
+++ b/src/main/java/io/kestra/plugin/kubernetes/AbstractPod.java
@@ -179,7 +179,7 @@ abstract public class AbstractPod extends AbstractConnection {
         ContainerBuilder containerBuilder = new ContainerBuilder()
             .withName(finished ? SIDECAR_FILES_CONTAINER_NAME : INIT_FILES_CONTAINER_NAME)
             .withImage(fileSidecar != null ? runContext.render(fileSidecar.getImage()).as(String.class).orElse("busybox") : "busybox")
-            .withResources(fileSidecar != null ? fileSidecar.getResources() : null)
+            .withResources(fileSidecar != null ? runContext.render(fileSidecar.getResources()).as(ResourceRequirements.class).orElse(null) : null)
             .withCommand(Arrays.asList(
                 "sh",
                 "-c",
@@ -203,6 +203,7 @@ abstract public class AbstractPod extends AbstractConnection {
         return new ContainerBuilder()
             .withName(INIT_FILES_CONTAINER_NAME)
             .withImage(fileSidecar != null ? runContext.render(fileSidecar.getImage()).as(String.class).orElse("busybox") : "busybox")
+            .withResources(fileSidecar != null ? runContext.render(fileSidecar.getResources()).as(ResourceRequirements.class).orElse(null) : null)
             .withCommand(Arrays.asList(
                 "sh",
                 "-c",

--- a/src/main/java/io/kestra/plugin/kubernetes/models/PropertyResourceRequirementsDeserializer.java
+++ b/src/main/java/io/kestra/plugin/kubernetes/models/PropertyResourceRequirementsDeserializer.java
@@ -1,0 +1,19 @@
+package io.kestra.plugin.kubernetes.models;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonNode;
+import io.fabric8.kubernetes.api.model.ResourceRequirements;
+import io.kestra.core.models.property.Property;
+
+import java.io.IOException;
+
+public class PropertyResourceRequirementsDeserializer extends JsonDeserializer<Property<ResourceRequirements>> {
+    @Override
+    public Property<ResourceRequirements> deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+        JsonNode node = p.getCodec().readTree(p);
+        ResourceRequirements value = p.getCodec().treeToValue(node, ResourceRequirements.class);
+        return Property.ofValue(value);
+    }
+}

--- a/src/main/java/io/kestra/plugin/kubernetes/models/SideCar.java
+++ b/src/main/java/io/kestra/plugin/kubernetes/models/SideCar.java
@@ -1,5 +1,6 @@
 package io.kestra.plugin.kubernetes.models;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import io.fabric8.kubernetes.api.model.ResourceRequirements;
 import io.kestra.core.models.property.Property;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -20,5 +21,6 @@ public class SideCar {
     @Schema(
         title = "The resource requirements applied to the file sidecar container."
     )
+    @JsonDeserialize(using = PropertyResourceRequirementsDeserializer.class)
     private Property<ResourceRequirements> resources;
 }

--- a/src/main/java/io/kestra/plugin/kubernetes/models/SideCar.java
+++ b/src/main/java/io/kestra/plugin/kubernetes/models/SideCar.java
@@ -1,7 +1,6 @@
 package io.kestra.plugin.kubernetes.models;
 
 import io.fabric8.kubernetes.api.model.ResourceRequirements;
-import io.kestra.core.models.annotations.PluginProperty;
 import io.kestra.core.models.property.Property;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
@@ -21,8 +20,5 @@ public class SideCar {
     @Schema(
         title = "The resource requirements applied to the file sidecar container."
     )
-    @PluginProperty(
-        additionalProperties = ResourceRequirements.class
-    )
-    private ResourceRequirements resources;
+    private Property<ResourceRequirements> resources;
 }

--- a/src/main/java/io/kestra/plugin/kubernetes/models/SideCar.java
+++ b/src/main/java/io/kestra/plugin/kubernetes/models/SideCar.java
@@ -1,5 +1,6 @@
 package io.kestra.plugin.kubernetes.models;
 
+import io.fabric8.kubernetes.api.model.ResourceRequirements;
 import io.kestra.core.models.annotations.PluginProperty;
 import io.kestra.core.models.property.Property;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -16,4 +17,12 @@ public class SideCar {
     )
     @Builder.Default
     private Property<String> image = Property.ofValue("busybox");
+
+    @Schema(
+        title = "The resource requirements applied to the file sidecar container."
+    )
+    @PluginProperty(
+        additionalProperties = ResourceRequirements.class
+    )
+    private ResourceRequirements resources;
 }

--- a/src/test/java/io/kestra/plugin/kubernetes/PodCreateTest.java
+++ b/src/test/java/io/kestra/plugin/kubernetes/PodCreateTest.java
@@ -2,6 +2,8 @@ package io.kestra.plugin.kubernetes;
 
 import com.google.common.io.CharStreams;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.api.model.Quantity;
+import io.fabric8.kubernetes.api.model.ResourceRequirements;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.kestra.core.junit.annotations.KestraTest;
 import io.kestra.core.models.executions.Execution;
@@ -18,6 +20,7 @@ import io.kestra.core.tenant.TenantService;
 import io.kestra.core.utils.Await;
 import io.kestra.core.utils.IdUtils;
 import io.kestra.core.utils.TestsUtils;
+import io.kestra.plugin.kubernetes.models.SideCar;
 import io.kestra.plugin.kubernetes.services.PodService;
 import jakarta.inject.Inject;
 import jakarta.inject.Named;
@@ -311,6 +314,94 @@ class PodCreateTest {
         assertThat(content.trim(), is("hello from pod"));
     }
 
+    @Test
+    void sidecarResources() throws Exception {
+        ResourceRequirements reqs = new ResourceRequirements();
+        reqs.setLimits(Map.of(
+            "cpu", Quantity.parse("200m"),
+            "memory", Quantity.parse("256Mi")));
+        reqs.setRequests(Map.of(
+            "cpu", Quantity.parse("100m"),
+            "memory", Quantity.parse("128Mi")));
+
+        PodCreate task = PodCreate.builder()
+            .id(PodCreate.class.getSimpleName())
+            .type(PodCreate.class.getName())
+            .namespace(Property.ofValue("default"))
+            .fileSidecar(SideCar.builder()
+                .resources(Property.ofValue(reqs))
+                .build())
+            .inputFiles(Map.of(
+                "in.txt", "File content"
+            ))
+            .outputFiles(Property.ofValue(List.of("out.txt")))
+            .waitForLogInterval(Property.ofValue(Duration.ofSeconds(30)))
+            .spec(TestUtils.convert(
+                ObjectMeta.class,
+                "containers:",
+                "- name: in-out-files",
+                "  image: debian:stable-slim",
+                "  command: [\"/bin/sh\"]",
+                "  args:",
+                "    - -c",
+                "    - >-",
+                "      cat {{ workingDir }}/in.txt > {{ workingDir }}/out.txt",
+                "restartPolicy: Never"
+            ))
+            .build();
+
+        Flow flow = TestsUtils.mockFlow();
+        Execution execution = TestsUtils.mockExecution(flow, Map.of());
+        TaskRun taskRun = TestsUtils.mockTaskRun(execution, task);
+        RunContext runContext = TestsUtils.mockRunContext(runContextFactory, task, Map.of());
+        RunContext finalRunContext = runContextInitializer.forWorker((DefaultRunContext) runContext, WorkerTask.builder().task(task).taskRun(taskRun).build());
+
+        final PodCreate.Output[] run = new PodCreate.Output[1];
+        ExecutorService executorService = Executors.newSingleThreadExecutor();
+        executorService.submit(() -> {
+            try {
+                run[0] = task.run(finalRunContext);
+            } catch (Exception e) {
+                log.debug("Unexpected error.", e);
+            }
+        });
+
+        String labelSelector = "kestra.io/taskrun-id=" + taskRun.getId();
+
+        try (KubernetesClient client = PodService.client(finalRunContext, null)) {
+            Await.until(() -> {
+                var pods = client.pods().inNamespace("default").withLabelSelector(labelSelector).list().getItems();
+                return !pods.isEmpty() && pods.getFirst().getStatus().getPhase().equals("Running");
+            }, Duration.ofMillis(200), Duration.ofMinutes(1));
+
+            var createdPod = client.pods().inNamespace("default").withLabelSelector(labelSelector).list().getItems().getFirst();
+            assertThat(createdPod.getStatus().getPhase(), is("Running"));
+            String podName = createdPod.getMetadata().getName();
+            log.info("Test detected pod creation: {}", podName);
+
+            ResourceRequirements initReqs = createdPod.getSpec().getInitContainers().getFirst().getResources();
+            assertThat(initReqs.getLimits().get("cpu"), is(reqs.getLimits().get("cpu")));
+            assertThat(initReqs.getLimits().get("memory"), is(reqs.getLimits().get("memory")));
+            assertThat(initReqs.getRequests().get("cpu"), is(reqs.getRequests().get("cpu")));
+            assertThat(initReqs.getRequests().get("memory"), is(reqs.getRequests().get("memory")));
+
+            ResourceRequirements sideReqs = createdPod.getSpec().getContainers().getLast().getResources();
+            assertThat(sideReqs.getLimits().get("cpu"), is(reqs.getLimits().get("cpu")));
+            assertThat(sideReqs.getLimits().get("memory"), is(reqs.getLimits().get("memory")));
+            assertThat(sideReqs.getRequests().get("cpu"), is(reqs.getRequests().get("cpu")));
+            assertThat(sideReqs.getRequests().get("memory"), is(reqs.getRequests().get("memory")));
+
+            Await.until(() -> client.pods().inNamespace("default").withLabelSelector(labelSelector).list().getItems().isEmpty(),
+                Duration.ofMillis(200), Duration.ofMinutes(1));
+
+            log.info("Pod {} has successfully completed.", podName);
+        }
+
+        assertThat(run[0].getOutputFiles(), hasKey("out.txt"));
+        InputStream file = storageInterface.get(TenantService.MAIN_TENANT, null, run[0].getOutputFiles().get("out.txt"));
+        String content = CharStreams.toString(new InputStreamReader(file));
+        assertThat(content.trim(), is("File content"));
+    }
 
     @Test
     void kill() throws Exception {


### PR DESCRIPTION
In envs with resource quotas, this will simplify deployment a lot.

### What changes are being made and why?

Sidecar config was extended by `resources` which expects std. resource requirements.

---

### How the changes have been QAed?

I tested the updated plugin, without and with resource reqs. and with applying them via plugin defaults.

