### PR TITLE
properly encode output files with special chars

### DIFF
--- a/src/main/java/io/kestra/plugin/kubernetes/AbstractPod.java
+++ b/src/main/java/io/kestra/plugin/kubernetes/AbstractPod.java
@@ -16,6 +16,7 @@ import org.slf4j.Logger;
 
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
@@ -105,7 +106,9 @@ abstract public class AbstractPod extends AbstractConnection {
                 .filter(path -> !Files.isDirectory(path) && Files.isReadable(path))
                 .forEach(throwConsumer(outputFile -> {
                     Path relativePathFromContainerWDir = runContext.workingDir().resolve(Path.of("working-dir/kestra/working-dir/")).relativize(outputFile);
-                    Path resolvedOutputFile = runContext.workingDir().resolve(relativePathFromContainerWDir);
+                    // Sanitize the resolved path by encoding special characters
+                    Path sanitizedOutputFile = Path.of(java.net.URLEncoder.encode(relativePathFromContainerWDir.toString(), StandardCharsets.UTF_8));
+                    Path resolvedOutputFile = runContext.workingDir().resolve(sanitizedOutputFile);
                     moveFile(outputFile, resolvedOutputFile);
                 }));
         }

--- a/src/main/java/io/kestra/plugin/kubernetes/AbstractPod.java
+++ b/src/main/java/io/kestra/plugin/kubernetes/AbstractPod.java
@@ -106,9 +106,13 @@ abstract public class AbstractPod extends AbstractConnection {
                 .filter(path -> !Files.isDirectory(path) && Files.isReadable(path))
                 .forEach(throwConsumer(outputFile -> {
                     Path relativePathFromContainerWDir = runContext.workingDir().resolve(Path.of("working-dir/kestra/working-dir/")).relativize(outputFile);
-                    // Sanitize the resolved path by encoding special characters
-                    Path sanitizedOutputFile = Path.of(java.net.URLEncoder.encode(relativePathFromContainerWDir.toString(), StandardCharsets.UTF_8));
-                    Path resolvedOutputFile = runContext.workingDir().resolve(sanitizedOutputFile);
+                    // Split path into components and sanitize by encoding special characters
+                    Path resolvedOutputFile = runContext.workingDir().path();
+                    for (int i = 0; i < relativePathFromContainerWDir.getNameCount(); i++) {
+                        resolvedOutputFile = resolvedOutputFile.resolve(Path.of(java.net.URLEncoder.encode(
+                            relativePathFromContainerWDir.getName(i).toString(),
+                            StandardCharsets.UTF_8)));
+                    }
                     moveFile(outputFile, resolvedOutputFile);
                 }));
         }

--- a/src/main/java/io/kestra/plugin/kubernetes/PodCreate.java
+++ b/src/main/java/io/kestra/plugin/kubernetes/PodCreate.java
@@ -18,6 +18,7 @@ import io.kestra.core.models.tasks.RunnableTask;
 import io.kestra.core.runners.DefaultRunContext;
 import io.kestra.core.runners.FilesService;
 import io.kestra.core.runners.RunContext;
+import io.kestra.core.utils.IdUtils;
 import io.kestra.core.utils.ThreadMainFactoryBuilder;
 import io.kestra.plugin.kubernetes.models.Connection;
 import io.kestra.plugin.kubernetes.models.Metadata;
@@ -34,13 +35,16 @@ import org.slf4j.Logger;
 
 import java.io.InterruptedIOException;
 import java.net.URI;
+import java.nio.file.Path;
 import java.time.Duration;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
 
 import jakarta.validation.constraints.NotNull;
 
+import static io.kestra.core.utils.Rethrow.throwFunction;
 import static io.kestra.plugin.kubernetes.services.PodService.waitForCompletion;
 
 @SuperBuilder
@@ -260,8 +264,8 @@ public class PodCreate extends AbstractPod implements RunnableTask<PodCreate.Out
                             .filter(containerStatus -> containerStatus.getState().getTerminated() != null && Objects.equals(containerStatus.getState().getTerminated().getReason(), "ContainerCannotRun"))
                             .forEach(containerStatus -> logger.error(containerStatus.getState().getTerminated().getMessage()));
                     } else if (this.outputFiles != null) {
-                        this.downloadOutputFiles(runContext, PodService.podRef(client, pod), logger, additionalVars);
-                        output.outputFiles(FilesService.outputFiles(runContext, runContext.render(this.outputFiles).asList(String.class)));
+                        Map<Path, Path> pathMap = this.downloadOutputFiles(runContext, PodService.podRef(client, pod), logger, additionalVars);
+                        output.outputFiles(outputFiles(runContext, runContext.render(this.outputFiles).asList(String.class), pathMap));
                     }
 
                     delete(client, logger, pod, runContext);
@@ -280,6 +284,36 @@ public class PodCreate extends AbstractPod implements RunnableTask<PodCreate.Out
             currentNamespace = null;
             currentConnection = null;
         }
+    }
+
+    // This and the following method were copied from FilesService and adapted. Cleaner solution might be to move them
+    // to FilesService with an optional pathMap parameter as any consumer of the method might have the same issues with
+    // spaces in file paths.
+    public static Map<String, URI> outputFiles(RunContext runContext, List<String> outputs, Map<Path, Path> pathMap) throws Exception {
+        List<String> renderedOutputs = outputs != null ? runContext.render(outputs) : null;
+        List<Path> allFilesMatching = runContext.workingDir().findAllFilesMatching(renderedOutputs);
+        var outputFiles = allFilesMatching.stream()
+            .map(throwFunction(path -> {
+                Path unsanitizedRelative = pathMap.get(path);
+                if (unsanitizedRelative == null) {
+                    throw new IllegalStateException("No unsanitized relative file path found for " + path);
+                }
+                return new AbstractMap.SimpleEntry<>(
+                    unsanitizedRelative.toString(),
+                    runContext.storage().putFile(path.toFile(), resolveUniqueNameForFile(path))
+                );
+            }))
+            .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+
+        if (runContext.logger().isTraceEnabled()) {
+            runContext.logger().trace("Captured {} output file(s).", allFilesMatching.size());
+        }
+
+        return outputFiles;
+    }
+
+    private static String resolveUniqueNameForFile(final Path path) {
+        return IdUtils.from(path.toString()) + "-" + path.toFile().getName();
     }
 
     private Pod createPod(RunContext runContext, KubernetesClient client, String namespace, Map<String, Object> additionalVars) throws java.io.IOException, io.kestra.core.exceptions.IllegalVariableEvaluationException {

--- a/src/test/java/io/kestra/plugin/kubernetes/PodCreateTest.java
+++ b/src/test/java/io/kestra/plugin/kubernetes/PodCreateTest.java
@@ -424,9 +424,9 @@ class PodCreateTest {
                 "  args:",
                 "    - -c",
                 "    - >-",
-                "      touch {{ workingDir }}/special\\ file.txt &&",
+                "      echo 'I am fulfilled' > {{ workingDir }}/special\\ file.txt &&",
                 "      mkdir {{ workingDir }}/sub\\ dir &&",
-                "      touch {{ workingDir }}/sub\\ dir/more\\ special\\ file.txt",
+                "      echo 'I have content' > {{ workingDir }}/sub\\ dir/more\\ special\\ file.txt",
                 "restartPolicy: Never"
             ))
             .build();
@@ -444,6 +444,14 @@ class PodCreateTest {
 
         assertThat(run.getOutputFiles(), hasKey("special file.txt"));
         assertThat(run.getOutputFiles(), hasKey("sub dir/more special file.txt"));
+
+        InputStream file = storageInterface.get(TenantService.MAIN_TENANT, null, run.getOutputFiles().get("special file.txt"));
+        String content = CharStreams.toString(new InputStreamReader(file));
+        assertThat(content.trim(), is("I am fulfilled"));
+
+        file = storageInterface.get(TenantService.MAIN_TENANT, null, run.getOutputFiles().get("sub dir/more special file.txt"));
+        content = CharStreams.toString(new InputStreamReader(file));
+        assertThat(content.trim(), is("I have content"));
     }
 
     @Test

--- a/src/test/java/io/kestra/plugin/kubernetes/PodCreateTest.java
+++ b/src/test/java/io/kestra/plugin/kubernetes/PodCreateTest.java
@@ -442,8 +442,8 @@ class PodCreateTest {
 
         PodCreate.Output run = task.run(runContext);
 
-        assertThat(run.getOutputFiles(), hasKey("special+file.txt"));
-        assertThat(run.getOutputFiles(), hasKey("sub+dir/more+special+file.txt"));
+        assertThat(run.getOutputFiles(), hasKey("special file.txt"));
+        assertThat(run.getOutputFiles(), hasKey("sub dir/more special file.txt"));
     }
 
     @Test

--- a/src/test/java/io/kestra/plugin/kubernetes/PodCreateTest.java
+++ b/src/test/java/io/kestra/plugin/kubernetes/PodCreateTest.java
@@ -413,7 +413,7 @@ class PodCreateTest {
             .id(PodCreate.class.getSimpleName())
             .type(PodCreate.class.getName())
             .namespace(Property.ofValue("default"))
-            .outputFiles(Property.ofValue(List.of("*.txt")))
+            .outputFiles(Property.ofValue(List.of("**.txt")))
             .waitForLogInterval(Property.ofValue(Duration.ofSeconds(30)))
             .spec(TestUtils.convert(
                 ObjectMeta.class,
@@ -424,7 +424,9 @@ class PodCreateTest {
                 "  args:",
                 "    - -c",
                 "    - >-",
-                "      touch {{ workingDir }}/special\\ file.txt",
+                "      touch {{ workingDir }}/special\\ file.txt &&",
+                "      mkdir {{ workingDir }}/sub\\ dir &&",
+                "      touch {{ workingDir }}/sub\\ dir/more\\ special\\ file.txt",
                 "restartPolicy: Never"
             ))
             .build();
@@ -441,6 +443,7 @@ class PodCreateTest {
         PodCreate.Output run = task.run(runContext);
 
         assertThat(run.getOutputFiles(), hasKey("special+file.txt"));
+        assertThat(run.getOutputFiles(), hasKey("sub+dir/more+special+file.txt"));
     }
 
     @Test


### PR DESCRIPTION
### What changes are being made and why?

URI encode output files to not run into issues with spaces or other special chars

### How the changes have been QAed?

Added a UT that was failing before and tested it with a workflow using the plugin