### PR TITLE
refactor(kubectl): move namespace to abstract class

### DIFF
--- a/.github/setup-unit.sh
+++ b/.github/setup-unit.sh
@@ -1,5 +1,5 @@
 curl -Lo ./kind "https://kind.sigs.k8s.io/dl/v0.20.0/kind-linux-amd64"
 chmod +x ./kind
-kind create cluster
+./kind create cluster
 curl -LO "https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl"
 chmod +x ./kubectl

--- a/src/main/java/io/kestra/plugin/kubernetes/AbstractPod.java
+++ b/src/main/java/io/kestra/plugin/kubernetes/AbstractPod.java
@@ -10,6 +10,7 @@ import io.kestra.core.runners.RunContext;
 import io.kestra.plugin.kubernetes.models.SideCar;
 import io.kestra.plugin.kubernetes.services.PodService;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
 import org.slf4j.Logger;
@@ -32,7 +33,7 @@ import static io.kestra.plugin.kubernetes.services.PodService.withRetries;
 @EqualsAndHashCode
 @Getter
 @NoArgsConstructor
-abstract public class AbstractPod extends AbstractConnection {
+public abstract class AbstractPod extends AbstractConnection {
     protected static final String INIT_FILES_CONTAINER_NAME = "init-files";
     protected static final String SIDECAR_FILES_CONTAINER_NAME = "out-files";
     protected static final String FILES_VOLUME_NAME = "kestra-files";
@@ -40,6 +41,14 @@ abstract public class AbstractPod extends AbstractConnection {
     // Constants for marker files used in file transfer coordination
     protected static final String READY_MARKER = "ready";
     protected static final String ENDED_MARKER = "ended";
+
+    @Schema(
+        title = "The namespace where the operation will be done",
+        description = "The Kubernetes namespace in which to execute the operation. Defaults to 'default' if not specified."
+    )
+    @NotNull
+    @Builder.Default
+    protected Property<String> namespace = Property.ofValue("default");
 
     @Schema(
         title = "The files from the container filesystem to send to Kestra's internal storage",
@@ -57,7 +66,6 @@ abstract public class AbstractPod extends AbstractConnection {
         dynamic = true
     )
     protected Object inputFiles;
-
 
     @Schema(
         title = "The configuration of the file sidecar container that handles the download and upload of files"

--- a/src/main/java/io/kestra/plugin/kubernetes/core/PodCreate.java
+++ b/src/main/java/io/kestra/plugin/kubernetes/core/PodCreate.java
@@ -209,13 +209,6 @@ import lombok.extern.slf4j.Slf4j;
 )
 @Slf4j
 public class PodCreate extends AbstractPod implements RunnableTask<PodCreate.Output> {
-    @Schema(
-        title = "The namespace where the pod will be created",
-        description = "The Kubernetes namespace in which to create the pod. Defaults to 'default' if not specified."
-    )
-    @NotNull
-    @Builder.Default
-    private Property<String> namespace = Property.ofValue("default");
 
     @Schema(
         title = "The pod metadata configuration",

--- a/src/main/java/io/kestra/plugin/kubernetes/kubectl/Delete.java
+++ b/src/main/java/io/kestra/plugin/kubernetes/kubectl/Delete.java
@@ -52,12 +52,6 @@ import java.util.List;
 public class Delete extends AbstractPod implements RunnableTask<VoidOutput> {
 
     @Schema(
-        title = "The Kubernetes namespace"
-    )
-    @NotNull
-    private Property<String> namespace;
-
-    @Schema(
         title = "The Kubernetes resource type (= kind) (e.g., pod, service)"
     )
     @NotNull
@@ -84,26 +78,26 @@ public class Delete extends AbstractPod implements RunnableTask<VoidOutput> {
 
         try (KubernetesClient client = PodService.client(runContext, this.getConnection())) {
 
-            var renderedNamespace = runContext.render(this.namespace).as(String.class)
+            var rNamespace = runContext.render(this.namespace).as(String.class)
                 .orElseThrow(() -> new IllegalArgumentException("namespace must be provided and rendered."));
-            var renderedKind = runContext.render(this.resourceType).as(String.class)
+            var rResourceType = runContext.render(this.resourceType).as(String.class)
                 .orElseThrow(() -> new IllegalArgumentException("resourceType must be provided and rendered."));
-            var renderedResourcesNames = runContext.render(this.resourcesNames).asList(String.class);
-            var renderedApiGroup = runContext.render(this.apiGroup).as(String.class).orElse("");
-            var renderedApiVersion = runContext.render(this.apiVersion).as(String.class).orElse("v1");
+            var rResourcesNames = runContext.render(this.resourcesNames).asList(String.class);
+            var rApiGroup = runContext.render(this.apiGroup).as(String.class).orElse("");
+            var rApiVersion = runContext.render(this.apiVersion).as(String.class).orElse("v1");
 
-            runContext.logger().debug("Deleting resource(s) '{}' of kind '{}' in namespace '{}'", renderedResourcesNames, renderedKind, renderedNamespace);
+            runContext.logger().debug("Deleting resource(s) '{}' of kind '{}' in namespace '{}'", rResourcesNames, rResourceType, rNamespace);
 
             var resourceDefinitionContext = new ResourceDefinitionContext.Builder()
-                .withGroup(renderedApiGroup)
-                .withVersion(renderedApiVersion)
-                .withKind(renderedKind)
+                .withGroup(rApiGroup)
+                .withVersion(rApiVersion)
+                .withKind(rResourceType)
                 .withNamespaced(true) // Assuming resources are namespaced as we take namespace input
                 .build();
 
-            renderedResourcesNames.forEach(name ->
+            rResourcesNames.forEach(name ->
                 client.genericKubernetesResources(resourceDefinitionContext)
-                    .inNamespace(renderedNamespace)
+                    .inNamespace(rNamespace)
                     .withName(name)
                     .delete()
             );

--- a/src/main/java/io/kestra/plugin/kubernetes/kubectl/Patch.java
+++ b/src/main/java/io/kestra/plugin/kubernetes/kubectl/Patch.java
@@ -196,12 +196,6 @@ public class Patch extends AbstractPod implements RunnableTask<Patch.Output> {
 
     @NotNull
     @Schema(
-        title = "The Kubernetes namespace"
-    )
-    private Property<String> namespace;
-
-    @NotNull
-    @Schema(
         title = "The Kubernetes resource type (e.g., deployment, statefulset, pod)",
         description = "Note: Currently only namespaced resources are supported. Cluster-scoped resources (e.g., ClusterRole, Node) are not supported."
     )
@@ -247,6 +241,7 @@ public class Patch extends AbstractPod implements RunnableTask<Patch.Output> {
 
     @Override
     public Output run(RunContext runContext) throws Exception {
+
         // Render all properties
         var rNamespace = runContext.render(this.namespace).as(String.class)
             .orElseThrow(() -> new IllegalArgumentException("namespace must be provided"));


### PR DESCRIPTION
closes https://github.com/kestra-io/plugin-kubernetes/issues/228 

<!-- Thanks for submitting a Pull Request to kestra. To help us review your contribution, please follow the guidelines below:

- Make sure that your commits follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) specification e.g. `feat(ui): add a new navigation menu item` or `fix(core): fix a bug in the core model` or `docs: update the README.md`. This will help us automatically generate the changelog.
- The title should briefly summarize the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share a flow example to help the reviewer understand and QA the change.
- Use "close" to automatically close an issue. For example, `close #1234` will close issue #1234. -->

### What changes are being made and why?
<!-- Please include a brief summary of the changes included in this PR e.g. closes #1234. -->

---

### How the changes have been QAed?

<!-- Include example code that shows how this PR has been QAed. The code should present a complete yet easily reproducible flow.

```yaml
# Your example flow code here
```

Note that this is not a replacement for unit tests but rather a way to demonstrate how the changes work in a real-life scenario, as the end-user would experience them.

Remove this section if this change applies to all flows or to the documentation only. -->

---

### Setup Instructions

<!--If there are any setup requirements like API keys or trial accounts, kindly include brief bullet-points-description outlining the setup process below.

- [External System Documentation](URL)
- Steps to set up the necessary resources

If there are no setup requirements, you can remove this section.

Thank you for your contribution. ❤️  -->

---

### Contributor Checklist ✅

- [ ] PR Title and commits follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Add a `closes #ISSUE_ID` or `fixes #ISSUE_ID` in the description if the PR relates to an opened issue.
- [ ] Documentation updated (plugin docs from `@Schema` for properties and outputs, `@Plugin` with examples, `README.md` file with basic knowledge and specifics).
- [ ] Setup instructions included if needed (API keys, accounts, etc.).
- [ ] Prefix all rendered properties by `r` not `rendered` (eg: `rHost`).
- [ ] Use `runContext.logger()` to log enough important infos where it's needed and with the best level (DEBUG, INFO, WARN or ERROR).

⚙️ **Properties**
- [ ] Properties are declared with `Property<T>` carrier type, do **not** use `@PluginProperty`.
- [ ] Mandatory properties must be annotated with `@NotNull` and checked during the rendering.
- [ ] You can model a JSON thanks to a simple `Property<Map<String, Object>>`.

🌐 **HTTP**
- [ ] Must use Kestra’s internal HTTP client from `io.kestra.core.http.client`

📦 **JSON**
- [ ] If you are serializing response from an external API, you may have to add a `@JsonIgnoreProperties(ignoreUnknown = true)` at the mapped class level. So that we will avoid to crash the plugin if the provider add a new field suddenly.
- [ ] Must use Jackson mappers provided by core (`io.kestra.core.serializers`)

✨ **New plugins / subplugins**
- [ ] Make sure your new plugin is configured like mentioned [here](https://kestra.io/docs/plugin-developer-guide/gradle#mandatory-configuration).
- [ ] Add a `package-info.java` under each sub package respecting [this format](https://github.com/kestra-io/plugin-odoo/blob/main/src/main/java/io/kestra/plugin/odoo/package-info.java) and choosing the right category.
- [ ] Every time you use `runContext.metric(...)` you have to add a `@Metric` ([see this doc](https://kestra.io/docs/plugin-developer-guide/document#document-the-plugin-metrics))
- [ ] Docs don't support to have both tasks/triggers in the root package (e.g. `io.kestra.plugin.kubernetes`) and in a sub package (e.g. `io.kestra.plugin.kubernetes.kubectl`), whether it's: all tasks/triggers in the root package OR only tasks/triggers in sub packages.
- [ ] Icons added in `src/main/resources/icons` in SVG format and not in thumbnail (keep it big):
  - `plugin-icon.svg`
  - One icon per package, e.g. `io.kestra.plugin.aws.svg`
  - For subpackages, e.g. `io.kestra.plugin.aws.s3`, add `io.kestra.plugin.aws.s3.svg`
    See example [here](https://github.com/kestra-io/plugin-elasticsearch/blob/master/src/main/java/io/kestra/plugin/elasticsearch/Search.java#L76).
- [ ] Use `"{{ secret('YOUR_SECRET') }}"` in the examples for sensible infos such as an API KEY.
- [ ] If you are fetching data (one, many or too many), you must add a `Property<FetchType> fetchType` to be able to use `FETCH_ONE`, `FETCH` and even `STORE` to store big amount of data in the internal storage.
- [ ] Align the `"""` to close examples blocks with the flow id.

🧪 **Tests**
- [ ] Unit Tests added or updated to cover the change (using the `RunContext` to actually run tasks).
- [ ] Add sanity checks if possible with a YAML flow inside `src/test/resources/flows`.
- [ ] Avoid disabling tests for CI. Instead, configure a local environment whenever it's possible with `.github/setup-unit.sh` (to be set executable with `chmod +x setup-unit.sh`) (which can be executed locally and in the CI) all along with a new `docker-compose-ci.yml` file (do **not** edit the existing `docker-compose.yml`). If needed, create an executable (`chmod +x cleanup-unit.sh`) `cleanup-unit.sh` to remove the potential costly resources (tables, datasets, etc).
- [ ] Provide screenshots from your QA / tests locally in the PR description. The goal here is to use the JAR of the plugin and directly test it locally in Kestra UI to ensure it integrates well.

📤 **Outputs**
- [ ] Do not send back as outputs the same infos you already have in your properties.
- [ ] If you do not have any output use `VoidOutput`.
- [ ] Do not output twice the same infos (eg: a status code, an error code saying the same thing...).
