### PR TITLE
docs(kubernetes): add OpenShift example

### DIFF
--- a/src/main/java/io/kestra/plugin/kubernetes/kubectl/Apply.java
+++ b/src/main/java/io/kestra/plugin/kubernetes/kubectl/Apply.java
@@ -1,5 +1,7 @@
 package io.kestra.plugin.kubernetes.kubectl;
 
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
@@ -300,7 +302,8 @@ public class Apply extends AbstractPod implements RunnableTask<Apply.Output> {
         var rWaitUntilReady = runContext.render(this.waitUntilReady).as(Duration.class).orElse(Duration.ZERO);
 
         try (var client = PodService.client(runContext, this.getConnection())) {
-            var resources = parseSpec(runContext.render(this.spec).as(String.class).orElseThrow());
+            var specStr = runContext.render(this.spec).as(String.class).orElseThrow();
+            var resources = client.load(new ByteArrayInputStream(specStr.getBytes(StandardCharsets.UTF_8))).items();
             Logger logger = runContext.logger();
             logger.debug("Parsed resources: {}", resources);
 

--- a/src/main/java/io/kestra/plugin/kubernetes/kubectl/Apply.java
+++ b/src/main/java/io/kestra/plugin/kubernetes/kubectl/Apply.java
@@ -170,6 +170,113 @@ import io.kestra.core.models.annotations.PluginProperty;
                       spec:
                         foo: bar
                 """
+        ),
+        @Example(
+            title = "Deploy an application to an OpenShift cluster, exposing it via a TLS-terminated Route.",
+            full = true,
+            code = """
+                id: openshift_deploy_python_app
+                namespace: company.devops
+
+                inputs:
+                  - id: image
+                    type: STRING
+                    description: "Full image reference to deploy, e.g. my-registry.example.com/company/python-app:1.0.0"
+
+                tasks:
+                  - id: deploy_to_openshift
+                    type: io.kestra.plugin.kubernetes.kubectl.Apply
+                    connection:
+                      masterUrl: "{{ secret('OPENSHIFT_API_URL') }}"
+                      oauthToken: "{{ secret('OPENSHIFT_TOKEN') }}"
+                    namespace: my-project
+                    spec: |-
+                      apiVersion: apps/v1
+                      kind: Deployment
+                      metadata:
+                        name: python-app
+                        labels:
+                          app: python-app
+                      spec:
+                        replicas: 2
+                        selector:
+                          matchLabels:
+                            app: python-app
+                        strategy:
+                          type: RollingUpdate
+                          rollingUpdate:
+                            maxSurge: 1
+                            maxUnavailable: 0
+                        template:
+                          metadata:
+                            labels:
+                              app: python-app
+                          spec:
+                            containers:
+                              # To track and proxy images through OpenShift's internal registry,
+                              # replace this with an ImageStream (image.openshift.io/v1) that imports
+                              # the tag via spec.tags, set lookupPolicy.local: true, and reference
+                              # the short name here instead of the full registry path.
+                              - name: python-app
+                                image: "{{ inputs.image }}"
+                                imagePullPolicy: Always
+                                ports:
+                                  - name: http
+                                    containerPort: 8080
+                                    protocol: TCP
+                                resources:
+                                  requests:
+                                    cpu: "100m"
+                                    memory: "128Mi"
+                                  limits:
+                                    cpu: "500m"
+                                    memory: "256Mi"
+                                readinessProbe:
+                                  httpGet:
+                                    path: /health
+                                    port: http
+                                  initialDelaySeconds: 10
+                                  periodSeconds: 5
+                                livenessProbe:
+                                  httpGet:
+                                    path: /health
+                                    port: http
+                                  initialDelaySeconds: 30
+                                  periodSeconds: 10
+                      ---
+                      apiVersion: v1
+                      kind: Service
+                      metadata:
+                        name: python-app-service
+                        labels:
+                          app: python-app
+                      spec:
+                        selector:
+                          app: python-app
+                        ports:
+                          - name: http
+                            port: 8080
+                            targetPort: http
+                        type: ClusterIP
+                      ---
+                      apiVersion: route.openshift.io/v1
+                      kind: Route
+                      metadata:
+                        name: python-app-route
+                        labels:
+                          app: python-app
+                      spec:
+                        to:
+                          kind: Service
+                          name: python-app-service
+                          weight: 100
+                        port:
+                          targetPort: http
+                        tls:
+                          termination: edge
+                          insecureEdgeTerminationPolicy: Redirect
+                        wildcardPolicy: None
+                """
         )
     }
 )


### PR DESCRIPTION
# PR: Add OpenShift example to `kubectl.Apply`

## Summary

Adds a new `@Example` to `io.kestra.plugin.kubernetes.kubectl.Apply` demonstrating deployment to a Red Hat OpenShift cluster. 

---

## What the example shows

The flow deploys a containerized application to OpenShift by applying three resources in a single `Apply` task using multi-document YAML (`---` separators):

| Resource | API | Purpose |
|---|---|---|
| `Deployment` | `apps/v1` | Runs 2 replicas with a zero-downtime rolling strategy |
| `Service` | `v1` | Exposes the pods inside the cluster on a named port |
| `Route` | `route.openshift.io/v1` | Exposes the service externally with TLS edge termination |

The image reference is a Kestra flow input (`inputs.image`), so upstream build steps in the same flow can pass a freshly built tag directly into this step without editing the manifest.

---

## Design decisions

**ImageStream omitted — by design**

An earlier draft included an `image.openshift.io/v1 ImageStream`. It was removed because:

- An ImageStream with no `spec.tags` is an empty catalog; it does not resolve the image in the Deployment.
- The `lookupPolicy.local: true` shortcut only works once the stream has a populated tag. Without that, the image reference falls through to a plain Docker pull, making the ImageStream decoration rather than function.
- 
A YAML comment in the example points teams that need OpenShift-native image tracking to the correct pattern: an ImageStream with `spec.tags` importing an external registry image, combined with `lookupPolicy.local: true` and a short-name image reference in the Deployment.

**`imagePullPolicy: Always`**

Changed from `IfNotPresent` to match the flow input model. When image tags are dynamic (e.g. a git SHA passed from a build step), `IfNotPresent` will silently run a stale cached layer if the tag has been reused. `Always` ensures the declared image is what actually runs.

**Named port `http` used consistently**

The container port, Service port, and Route `targetPort` all reference the name `http` rather than the integer `8080`. This keeps the three resources in sync if the port number ever changes, and is the pattern OpenShift documentation recommends for Routes.

**`insecureEdgeTerminationPolicy: Redirect`**

Plain HTTP requests to the Route are redirected to HTTPS automatically. Without this, edge-terminated Routes accept both HTTP and HTTPS, which is rarely the intended production behavior.

---

## Authentication

OpenShift uses OAuth bearer tokens, not basic auth. The example expects two secrets:

| Secret | How to obtain |
|---|---|
| `OPENSHIFT_API_URL` | `oc whoami --show-server` — format: `https://api.<cluster-domain>:6443` |
| `OPENSHIFT_TOKEN` | `oc whoami -t` after `oc login`, or a long-lived token from a `ServiceAccount` secret for CI use |

---

## What to adapt before use

- Replace the `image` input value with the full registry path for your image.
- The readiness and liveness probes assume a `/health` HTTP endpoint on port 8080. Adjust the path to match your application.
- `namespace: my-project` should be replaced with the target OpenShift project name.
- `replicas`, resource requests, and limits are illustrative starting points.
