### PR TITLE
fix(plugin-kubernetes): align @PluginSubGroup titles with metadata YAML

### DIFF
--- a/src/main/java/io/kestra/plugin/kubernetes/core/package-info.java
+++ b/src/main/java/io/kestra/plugin/kubernetes/core/package-info.java
@@ -1,4 +1,5 @@
 @PluginSubGroup(
+    title = "Kubernetes Core",
     description = "This subgroup of plugins contains core tasks for interacting with a Kubernetes cluster.",
     categories = { PluginSubGroup.PluginCategory.INFRASTRUCTURE }
 )

--- a/src/main/java/io/kestra/plugin/kubernetes/kubectl/package-info.java
+++ b/src/main/java/io/kestra/plugin/kubernetes/kubectl/package-info.java
@@ -1,4 +1,5 @@
 @PluginSubGroup(
+    title = "Kubernetes API (kubectl)",
     description = "This subgroup of plugins contains core tasks for interacting with a Kubernetes cluster through kubectl commands.",
     categories = { PluginSubGroup.PluginCategory.INFRASTRUCTURE }
 )


### PR DESCRIPTION
## Summary

- Updates `@PluginSubGroup(title = ...)` in `package-info.java` files to match the `title` field in the corresponding subgroup metadata YAML files
- Eliminates duplicate/empty subgroup URLs on kestra.io caused by the annotation falling back to the package name when no title is set, while metadata uses a different slug

## Test plan

- [ ] Verify kestra.io subgroup pages no longer show empty duplicate routes after merge