### PR TITLE
fix(runner): avoid waitUntilRunning timeout when resuming Running/Succeeded pod

### DIFF
--- a/src/main/java/io/kestra/plugin/kubernetes/core/PodCreate.java
+++ b/src/main/java/io/kestra/plugin/kubernetes/core/PodCreate.java
@@ -409,8 +409,10 @@ public class PodCreate extends AbstractPod implements RunnableTask<PodCreate.Out
 
                 try (Watch ignored = PodService.podRef(client, pod).watch(listOptions(runContext), new PodWatcher(logger))) {
                     try {
-                        // in case of resuming an already running pod, the status will be running
-                        if (!PodService.PodPhase.RUNNING.value().equals(pod.getStatus().getPhase())) {
+                        // Skip init-container setup and waitForPodReady for pods already running or completed (e.g. on resume).
+                        // Snapshot phase from the list call — fast-path GET in waitForContainersStartedOrCompleted is authoritative.
+                        var podPhase = Optional.ofNullable(pod.getStatus()).map(io.fabric8.kubernetes.api.model.PodStatus::getPhase).orElse(null);
+                        if (!PodService.PodPhase.RUNNING.value().equals(podPhase) && !PodService.isCompletedPhase(podPhase)) {
                             // wait for init container and upload files
                             if (validatedInputFiles != null) {
                                 // Files already validated and created before pod creation
@@ -439,7 +441,7 @@ public class PodCreate extends AbstractPod implements RunnableTask<PodCreate.Out
 
                         // Wait for containers to start (Running) or pod to reach terminal state (Succeeded/Failed/Unknown)
                         // This ensures we proceed with log collection regardless of pod outcome
-                        pod = PodService.waitForContainersStartedOrCompleted(client, pod, rWaitUntilRunning);
+                        pod = PodService.waitForContainersStartedOrCompleted(client, logger, pod, rWaitUntilRunning);
 
                         // Only start log streaming if pod is actually running
                         // For pods that complete quickly, fetchFinalLogs will handle log collection

--- a/src/main/java/io/kestra/plugin/kubernetes/services/PodService.java
+++ b/src/main/java/io/kestra/plugin/kubernetes/services/PodService.java
@@ -87,8 +87,36 @@ abstract public class PodService {
             );
     }
 
-    public static Pod waitForContainersStartedOrCompleted(KubernetesClient client, Pod pod, Duration waitUntilRunning) {
+    public static boolean isCompletedPhase(String phase) {
+        return phase != null && COMPLETED_PHASES.contains(phase);
+    }
+
+    private static boolean isStartedOrCompleted(Pod pod) {
+        if (pod == null || pod.getStatus() == null) {
+            return false;
+        }
+        var phase = pod.getStatus().getPhase();
+        if (isCompletedPhase(phase)) {
+            return true;
+        }
+        return PodPhase.RUNNING.value().equals(phase) &&
+            pod.getStatus().getContainerStatuses() != null &&
+            pod.getStatus().getContainerStatuses().stream()
+                .anyMatch(c -> c.getState() != null && c.getState().getRunning() != null);
+    }
+
+    public static Pod waitForContainersStartedOrCompleted(KubernetesClient client, Logger logger, Pod pod, Duration waitUntilRunning) {
         var podResource = podRef(client, pod);
+
+        // Fast path: pod already satisfies the condition (e.g. on resume with a Running/Succeeded pod)
+        var current = podResource.get();
+        if (current == null) {
+            throw new KubernetesClientException("Pod was deleted while waiting for containers to start: " + pod.getMetadata().getName());
+        }
+        if (isStartedOrCompleted(current)) {
+            return current;
+        }
+
         var remaining = waitUntilRunning;
         var chunk = Duration.ofMinutes(5);
 
@@ -98,13 +126,7 @@ abstract public class PodService {
 
             try {
                 var result = podResource.waitUntilCondition(
-                    j -> j != null &&
-                        j.getStatus() != null && ((PodPhase.RUNNING.value().equals(j.getStatus().getPhase()) &&
-                            j.getStatus().getContainerStatuses() != null &&
-                            j.getStatus().getContainerStatuses().stream()
-                                .anyMatch(c -> c.getState().getRunning() != null))
-                            ||
-                            COMPLETED_PHASES.contains(j.getStatus().getPhase())),
+                    PodService::isStartedOrCompleted,
                     waitTime.toSeconds(),
                     TimeUnit.SECONDS
                 );
@@ -114,12 +136,16 @@ abstract public class PodService {
             } catch (KubernetesClientTimeoutException e) {
                 // chunk expired — fall through to GET check
             } catch (KubernetesClientException e) {
-                // watch error — fall through to GET check
+                logger.debug("Watch error while waiting for containers to start after {}s, rechecking pod state", waitTime.toSeconds(), e);
             }
 
             podResource = podRef(client, pod);
-            if (podResource.get() == null) {
+            var polled = podResource.get();
+            if (polled == null) {
                 throw new KubernetesClientException("Pod was deleted while waiting for containers to start: " + pod.getMetadata().getName());
+            }
+            if (isStartedOrCompleted(polled)) {
+                return polled;
             }
         }
 

--- a/src/test/java/io/kestra/plugin/kubernetes/services/PodServiceTest.java
+++ b/src/test/java/io/kestra/plugin/kubernetes/services/PodServiceTest.java
@@ -1,23 +1,33 @@
 package io.kestra.plugin.kubernetes.services;
 
 import java.time.Duration;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
 
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.slf4j.Logger;
 
 import io.kestra.core.junit.annotations.KestraTest;
 
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodBuilder;
 import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClientException;
+import io.fabric8.kubernetes.client.KubernetesClientTimeoutException;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
 import io.fabric8.kubernetes.client.dsl.PodResource;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @KestraTest
@@ -68,5 +78,170 @@ class PodServiceTest {
         Pod result = PodService.waitForPodReady(client, pod, Duration.ofSeconds(1));
 
         assertNull(result);
+    }
+
+    @Test
+    void waitForContainersStartedOrCompletedShouldReturnImmediatelyWhenPodAlreadySucceeded() {
+        var client = mock(KubernetesClient.class);
+        var logger = mock(Logger.class);
+        var podResource = mock(PodResource.class);
+        var pod = new PodBuilder()
+            .withNewMetadata()
+            .withName("pod-succeeded")
+            .withNamespace("default")
+            .endMetadata()
+            .withNewStatus()
+            .withPhase("Succeeded")
+            .endStatus()
+            .build();
+
+        when(podResource.get()).thenReturn(pod);
+
+        try (var podService = Mockito.mockStatic(PodService.class, Mockito.CALLS_REAL_METHODS)) {
+            podService.when(() -> PodService.podRef(client, pod)).thenReturn(podResource);
+
+            var result = PodService.waitForContainersStartedOrCompleted(client, logger, pod, Duration.ofMinutes(30));
+
+            assertThat(result, is(pod));
+            // Fast path: no watch call should have been made
+            verify(podResource, never()).waitUntilCondition(any(), anyLong(), Mockito.eq(TimeUnit.SECONDS));
+        }
+    }
+
+    @Test
+    void waitForContainersStartedOrCompletedShouldReturnImmediatelyWhenPodAlreadyRunning() {
+        var client = mock(KubernetesClient.class);
+        var logger = mock(Logger.class);
+        var podResource = mock(PodResource.class);
+        var pod = new PodBuilder()
+            .withNewMetadata()
+            .withName("pod-running")
+            .withNamespace("default")
+            .endMetadata()
+            .withNewStatus()
+            .withPhase("Running")
+            .addNewContainerStatus()
+            .withName("main")
+            .withNewState().withNewRunning().endRunning().endState()
+            .endContainerStatus()
+            .endStatus()
+            .build();
+
+        when(podResource.get()).thenReturn(pod);
+
+        try (var podService = Mockito.mockStatic(PodService.class, Mockito.CALLS_REAL_METHODS)) {
+            podService.when(() -> PodService.podRef(client, pod)).thenReturn(podResource);
+
+            var result = PodService.waitForContainersStartedOrCompleted(client, logger, pod, Duration.ofMinutes(30));
+
+            assertThat(result, is(pod));
+            // Fast path: no watch call should have been made
+            verify(podResource, never()).waitUntilCondition(any(), anyLong(), Mockito.eq(TimeUnit.SECONDS));
+        }
+    }
+
+    @Test
+    void waitForContainersStartedOrCompletedShouldReturnOnFallbackGetAfterTimeoutWhenConditionSatisfied() {
+        var client = mock(KubernetesClient.class);
+        var logger = mock(Logger.class);
+        var podResource = mock(PodResource.class);
+        var pendingPod = new PodBuilder()
+            .withNewMetadata()
+            .withName("pod-pending")
+            .withNamespace("default")
+            .endMetadata()
+            .withNewStatus()
+            .withPhase("Pending")
+            .endStatus()
+            .build();
+        var succeededPod = new PodBuilder()
+            .withNewMetadata()
+            .withName("pod-pending")
+            .withNamespace("default")
+            .endMetadata()
+            .withNewStatus()
+            .withPhase("Succeeded")
+            .endStatus()
+            .build();
+
+        // Fast-path GET returns pending (no early return), watch times out, fallback GET returns succeeded
+        when(podResource.get()).thenReturn(pendingPod, succeededPod);
+        when(podResource.waitUntilCondition(any(), anyLong(), Mockito.eq(TimeUnit.SECONDS)))
+            .thenThrow(new KubernetesClientTimeoutException("Timed out", "Pod", "pod-pending", 10L, TimeUnit.SECONDS));
+
+        try (var podService = Mockito.mockStatic(PodService.class, Mockito.CALLS_REAL_METHODS)) {
+            podService.when(() -> PodService.podRef(client, pendingPod)).thenReturn(podResource);
+
+            var result = PodService.waitForContainersStartedOrCompleted(client, logger, pendingPod, Duration.ofMinutes(10));
+
+            assertThat(result, is(succeededPod));
+        }
+    }
+
+    @Test
+    void waitForContainersStartedOrCompletedShouldThrowWhenPodAlreadyDeletedOnFastPath() {
+        var client = mock(KubernetesClient.class);
+        var logger = mock(Logger.class);
+        var podResource = mock(PodResource.class);
+        var pod = new PodBuilder()
+            .withNewMetadata()
+            .withName("pod-1")
+            .withNamespace("default")
+            .endMetadata()
+            .withNewStatus()
+            .withPhase("Pending")
+            .endStatus()
+            .build();
+
+        // Fast-path GET returns null immediately — pod is already gone before watch is set up
+        when(podResource.get()).thenReturn(null);
+
+        try (var podService = Mockito.mockStatic(PodService.class, Mockito.CALLS_REAL_METHODS)) {
+            podService.when(() -> PodService.podRef(client, pod)).thenReturn(podResource);
+
+            var exception = assertThrows(
+                KubernetesClientException.class,
+                () -> PodService.waitForContainersStartedOrCompleted(client, logger, pod, Duration.ofMinutes(10))
+            );
+
+            assertThat(exception.getMessage(), is("Pod was deleted while waiting for containers to start: pod-1"));
+            // Only the fast-path GET should have been called; watch is never reached
+            Mockito.verify(podResource, Mockito.times(1)).get();
+            verify(podResource, never()).waitUntilCondition(any(), anyLong(), Mockito.eq(TimeUnit.SECONDS));
+        }
+    }
+
+    @Test
+    void waitForContainersStartedOrCompletedShouldThrowWhenPodDeletedAfterWatch() {
+        var client = mock(KubernetesClient.class);
+        var logger = mock(Logger.class);
+        var podResource = mock(PodResource.class);
+        var pendingPod = new PodBuilder()
+            .withNewMetadata()
+            .withName("pod-1")
+            .withNamespace("default")
+            .endMetadata()
+            .withNewStatus()
+            .withPhase("Pending")
+            .endStatus()
+            .build();
+
+        // Fast-path GET returns a non-started pod (watch is entered), watch chunk times out, fallback GET returns null
+        when(podResource.get()).thenReturn(pendingPod, (Pod) null);
+        when(podResource.waitUntilCondition(any(), anyLong(), Mockito.eq(TimeUnit.SECONDS)))
+            .thenThrow(new KubernetesClientTimeoutException("Timed out", "Pod", "pod-1", 10L, TimeUnit.SECONDS));
+
+        try (var podService = Mockito.mockStatic(PodService.class, Mockito.CALLS_REAL_METHODS)) {
+            podService.when(() -> PodService.podRef(client, pendingPod)).thenReturn(podResource);
+
+            var exception = assertThrows(
+                KubernetesClientException.class,
+                () -> PodService.waitForContainersStartedOrCompleted(client, logger, pendingPod, Duration.ofMinutes(10))
+            );
+
+            assertThat(exception.getMessage(), is("Pod was deleted while waiting for containers to start: pod-1"));
+            // Two GET calls: fast-path (returns pending) + fallback after watch timeout (returns null)
+            Mockito.verify(podResource, Mockito.times(2)).get();
+        }
     }
 }


### PR DESCRIPTION
## Summary

Ported from kestra-io/plugin-ee-kubernetes#139.

When the worker liveness coordinator restarts a task that was running on an existing pod, two code paths blocked for the full `waitUntilRunning` budget instead of returning immediately:

- **RC1 ()**: The resume guard only checked for `RUNNING` phase. Pods in `Succeeded`, `Failed`, or `Unknown` phase fell into the init-container / `waitForPodReady` block, timing out instead of skipping straight to log collection.

- **RC2 (`PodService.waitForContainersStartedOrCompleted`)**: No fast-path check before starting the watch loop. A pod already in `Running` or `Succeeded` state that emits no new events drained the full `waitUntilRunning` budget before timing out.

### Changes

- `PodService`: add `isCompletedPhase` / `isStartedOrCompleted` helpers; add fast-path GET before the watch loop; check condition (not just existence) on the fallback GET after each chunk timeout; add `Logger` parameter for debug-level watch error logging.
- `PodCreate`: extend the resume phase guard to also skip completed phases via `isCompletedPhase`; pass `logger` to `waitForContainersStartedOrCompleted`.

## Test plan

- [ ] All 6 unit tests in `PodServiceTest` pass (fast-path Succeeded, fast-path Running, fallback-GET after timeout, deletion on fast-path, deletion after watch, existing `waitForPodReady` regression)
- [ ] No integration test regressions