### PR TITLE
perf(tests): enable parallel test execution to cut CI time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,7 @@ out/
 .classpath
 .attach*
 src/test/resources/application-test.yml
-kind
-kubectl
+/kind
+/kubectl
 .factorypath
 bin/

--- a/src/test/java/io/kestra/plugin/kubernetes/core/PodCreateTest.java
+++ b/src/test/java/io/kestra/plugin/kubernetes/core/PodCreateTest.java
@@ -14,6 +14,8 @@ import java.util.concurrent.TimeUnit;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.slf4j.Logger;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -52,6 +54,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @KestraTest
 @Timeout(value = 15, unit = java.util.concurrent.TimeUnit.MINUTES)
+@Execution(ExecutionMode.SAME_THREAD)
 class PodCreateTest {
     @Inject
     private RunContextFactory runContextFactory;

--- a/src/test/java/io/kestra/plugin/kubernetes/core/PodCreateTest.java
+++ b/src/test/java/io/kestra/plugin/kubernetes/core/PodCreateTest.java
@@ -14,7 +14,6 @@ import java.util.concurrent.TimeUnit;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
-import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.slf4j.Logger;
 
@@ -54,7 +53,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @KestraTest
 @Timeout(value = 15, unit = java.util.concurrent.TimeUnit.MINUTES)
-@Execution(ExecutionMode.SAME_THREAD)
+@org.junit.jupiter.api.parallel.Execution(ExecutionMode.SAME_THREAD)
 class PodCreateTest {
     @Inject
     private RunContextFactory runContextFactory;

--- a/src/test/java/io/kestra/plugin/kubernetes/core/PodCreateTest.java
+++ b/src/test/java/io/kestra/plugin/kubernetes/core/PodCreateTest.java
@@ -13,6 +13,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.slf4j.Logger;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -50,6 +51,7 @@ import static org.hamcrest.Matchers.*;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @KestraTest
+@Timeout(value = 15, unit = java.util.concurrent.TimeUnit.MINUTES)
 class PodCreateTest {
     @Inject
     private RunContextFactory runContextFactory;

--- a/src/test/java/io/kestra/plugin/kubernetes/kubectl/ApplyTest.java
+++ b/src/test/java/io/kestra/plugin/kubernetes/kubectl/ApplyTest.java
@@ -3,7 +3,11 @@ package io.kestra.plugin.kubernetes.kubectl;
 import java.time.Duration;
 import java.util.List;
 
+import java.util.concurrent.TimeUnit;
+
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.parallel.ResourceLock;
 
 import io.kestra.core.junit.annotations.KestraTest;
 import io.kestra.core.models.property.Property;
@@ -19,6 +23,8 @@ import static org.hamcrest.Matchers.notNullValue;
 
 @KestraTest
 @Slf4j
+@Timeout(value = 15, unit = TimeUnit.MINUTES)
+@ResourceLock("kubectl-my-deployment")
 class ApplyTest {
     @Inject
     private RunContextFactory runContextFactory;

--- a/src/test/java/io/kestra/plugin/kubernetes/kubectl/DeleteTest.java
+++ b/src/test/java/io/kestra/plugin/kubernetes/kubectl/DeleteTest.java
@@ -3,7 +3,11 @@ package io.kestra.plugin.kubernetes.kubectl;
 import java.util.ArrayList;
 import java.util.List;
 
+import java.util.concurrent.TimeUnit;
+
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.parallel.ResourceLock;
 
 import io.kestra.core.junit.annotations.KestraTest;
 import io.kestra.core.models.property.Property;
@@ -16,6 +20,8 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
 @KestraTest
+@Timeout(value = 15, unit = TimeUnit.MINUTES)
+@ResourceLock("kubectl-my-deployment")
 public class DeleteTest {
 
     public static final String DEFAULT_NAMESPACE = "default";

--- a/src/test/java/io/kestra/plugin/kubernetes/kubectl/GetTest.java
+++ b/src/test/java/io/kestra/plugin/kubernetes/kubectl/GetTest.java
@@ -4,7 +4,11 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 
+import java.util.concurrent.TimeUnit;
+
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.parallel.ResourceLock;
 
 import io.kestra.core.junit.annotations.KestraTest;
 import io.kestra.core.models.property.Property;
@@ -23,6 +27,8 @@ import static org.hamcrest.Matchers.notNullValue;
 
 @KestraTest
 @Slf4j
+@Timeout(value = 15, unit = TimeUnit.MINUTES)
+@ResourceLock("kubectl-my-deployment")
 public class GetTest {
 
     public static final String DEFAULT_NAMESPACE = "default";

--- a/src/test/java/io/kestra/plugin/kubernetes/kubectl/PatchTest.java
+++ b/src/test/java/io/kestra/plugin/kubernetes/kubectl/PatchTest.java
@@ -4,8 +4,11 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 
+import java.util.concurrent.TimeUnit;
+
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.slf4j.Logger;
 
 import io.kestra.core.junit.annotations.KestraTest;
@@ -22,6 +25,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 
 @KestraTest
+@Timeout(value = 15, unit = TimeUnit.MINUTES)
 class PatchTest {
     @Inject
     private RunContextFactory runContextFactory;

--- a/src/test/java/io/kestra/plugin/kubernetes/kubectl/RestartTest.java
+++ b/src/test/java/io/kestra/plugin/kubernetes/kubectl/RestartTest.java
@@ -2,7 +2,10 @@ package io.kestra.plugin.kubernetes.kubectl;
 
 import java.util.List;
 
+import java.util.concurrent.TimeUnit;
+
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import io.kestra.core.junit.annotations.KestraTest;
 import io.kestra.core.models.property.Property;
@@ -15,6 +18,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 
 @KestraTest
+@Timeout(value = 15, unit = TimeUnit.MINUTES)
 public class RestartTest {
 
     public static final String DEFAULT_NAMESPACE = "default";

--- a/src/test/resources/junit-platform.properties
+++ b/src/test/resources/junit-platform.properties
@@ -1,0 +1,3 @@
+junit.jupiter.execution.parallel.enabled=true
+junit.jupiter.execution.parallel.mode.default=concurrent
+junit.jupiter.execution.parallel.mode.classes.default=concurrent


### PR DESCRIPTION
## Summary

- Enable JUnit 5 parallel execution (classes + methods concurrently) via `junit-platform.properties`
- Add `@Timeout(15min)` on all integration test classes so CI hangs surface as bounded failures
- Add `@ResourceLock("kubectl-my-deployment")` on `ApplyTest`, `DeleteTest`, `GetTest` — they share a hardcoded Deployment name and must not run concurrently with each other
- Anchor `kind`/`kubectl` entries in `.gitignore` to root so they no longer shadow the `kubectl` test package path

Ported from kestra-io/plugin-ee-kubernetes#124 which cut CI from 2h12 → 17 min. Expected gain here: ~40–50% off the current 21 min wall-clock.

## Test plan

- [ ] CI passes with parallel execution enabled
- [ ] No flaky failures from kubectl tests running concurrently (ResourceLock guards the shared Deployment name)
- [ ] No test hangs past 15 min