### PR TITLE
chore(deps): bump dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
     id "idea"
     id 'jacoco'
     id "com.adarshr.test-logger" version "4.0.0"
-    id "com.gradleup.shadow" version "9.4.1"
+    id "com.gradleup.shadow" version "9.4.2"
     id 'signing'
     id "com.github.ben-manes.versions" version "0.54.0"
     id 'net.researchgate.release' version '3.1.0'

--- a/build.gradle
+++ b/build.gradle
@@ -54,7 +54,7 @@ dependencies {
     compileOnly group: "io.kestra", name: "core", version: kestraVersion
 
     // plugins
-    api 'io.fabric8:kubernetes-client:7.6.1'
+    api 'io.fabric8:kubernetes-client:7.7.0'
     api group: 'org.apache.commons', name: 'commons-compress'
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.1-bin.zip
 networkTimeout=10000
 retries=0
 retryBackOffMs=500


### PR DESCRIPTION
## Summary

Consolidates the following Dependabot PRs into a single update:

- Bump `io.fabric8:kubernetes-client` from 7.6.1 to 7.7.0 (closes #286)
- Bump `gradle-wrapper` from 9.5.0 to 9.5.1 (closes #287)
- Bump `com.gradleup.shadow` from 9.4.1 to 9.4.2 (closes #290)

Closes #286, #287, #290