### PR TITLE
fix(apply): support core-group v1 resources via genericKubernetesResources

### DIFF
--- a/src/main/java/io/kestra/plugin/kubernetes/kubectl/Apply.java
+++ b/src/main/java/io/kestra/plugin/kubernetes/kubectl/Apply.java
@@ -16,6 +16,9 @@ import io.kestra.plugin.kubernetes.models.Metadata;
 import io.kestra.plugin.kubernetes.services.PodService;
 import io.kestra.plugin.kubernetes.services.ResourceWaitService;
 
+import io.fabric8.kubernetes.api.model.GenericKubernetesResource;
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.dsl.base.ResourceDefinitionContext;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
@@ -66,6 +69,34 @@ import io.kestra.core.models.annotations.PluginProperty;
                                 image: nginx:stable-alpine
                                 ports:
                                   - containerPort: 80
+                """
+        ),
+        @Example(
+            title = "Apply a core-group v1 Service.",
+            full = true,
+            code = """
+                id: create_or_replace_service
+                namespace: company.team
+
+                tasks:
+                  - id: apply
+                    type: io.kestra.plugin.kubernetes.kubectl.Apply
+                    connection:
+                      masterUrl: "{{ secret('K8S_MASTER_URL') }}"
+                      oauthToken: "{{ secret('K8S_TOKEN') }}"
+                    namespace: default
+                    spec: |-
+                      apiVersion: v1
+                      kind: Service
+                      metadata:
+                        name: my-service
+                      spec:
+                        selector:
+                          app: myapp
+                        ports:
+                          - protocol: TCP
+                            port: 80
+                            targetPort: 8080
                 """
         ),
         @Example(
@@ -199,10 +230,8 @@ public class Apply extends AbstractPod implements RunnableTask<Apply.Output> {
 
             List<Metadata> metadataList = new ArrayList<>();
             for (var resource : resources) {
-                var resourceClient = client.resource(resource).inNamespace(rNamespace);
-
                 try {
-                    var hasMetadata = resourceClient.unlock().serverSideApply();
+                    var hasMetadata = applyResource(client, resource, rNamespace);
                     metadataList.add(Metadata.from(hasMetadata.getMetadata()));
                     logger.info("Applied resource: {}", hasMetadata);
 
@@ -243,6 +272,27 @@ public class Apply extends AbstractPod implements RunnableTask<Apply.Output> {
                 .metadata(metadataList)
                 .build();
         }
+    }
+
+    private static HasMetadata applyResource(KubernetesClient client, HasMetadata resource, String namespace) {
+        if (resource instanceof GenericKubernetesResource generic) {
+            var apiVersion = generic.getApiVersion();
+            String group = "";
+            String version = apiVersion;
+            if (apiVersion != null && apiVersion.contains("/")) {
+                var parts = apiVersion.split("/", 2);
+                group = parts[0];
+                version = parts[1];
+            }
+            var context = new ResourceDefinitionContext.Builder()
+                .withGroup(group)
+                .withVersion(version)
+                .withKind(generic.getKind())
+                .withNamespaced(true)
+                .build();
+            return client.genericKubernetesResources(context).inNamespace(namespace).resource(generic).serverSideApply();
+        }
+        return client.resource(resource).inNamespace(namespace).unlock().serverSideApply();
     }
 
     @Getter

--- a/src/main/java/io/kestra/plugin/kubernetes/kubectl/Apply.java
+++ b/src/main/java/io/kestra/plugin/kubernetes/kubectl/Apply.java
@@ -242,18 +242,9 @@ public class Apply extends AbstractPod implements RunnableTask<Apply.Output> {
                         var apiVersion = hasMetadata.getApiVersion();
                         var kind = hasMetadata.getKind();
 
-                        // Parse apiVersion to extract group and version
-                        String group = "";
-                        String version = apiVersion;
-                        if (apiVersion != null && apiVersion.contains("/")) {
-                            String[] parts = apiVersion.split("/", 2);
-                            group = parts[0];
-                            version = parts[1];
-                        }
-
                         var resourceContext = new ResourceDefinitionContext.Builder()
-                            .withGroup(group)
-                            .withVersion(version)
+                            .withGroup(parseGroup(apiVersion))
+                            .withVersion(parseVersion(apiVersion))
                             .withKind(kind)
                             .withNamespaced(true)
                             .build();
@@ -277,22 +268,29 @@ public class Apply extends AbstractPod implements RunnableTask<Apply.Output> {
     private static HasMetadata applyResource(KubernetesClient client, HasMetadata resource, String namespace) {
         if (resource instanceof GenericKubernetesResource generic) {
             var apiVersion = generic.getApiVersion();
-            String group = "";
-            String version = apiVersion;
-            if (apiVersion != null && apiVersion.contains("/")) {
-                var parts = apiVersion.split("/", 2);
-                group = parts[0];
-                version = parts[1];
-            }
             var context = new ResourceDefinitionContext.Builder()
-                .withGroup(group)
-                .withVersion(version)
+                .withGroup(parseGroup(apiVersion))
+                .withVersion(parseVersion(apiVersion))
                 .withKind(generic.getKind())
-                .withNamespaced(true)
+                .withNamespaced(true) // Assuming resources are namespaced as we take namespace input
                 .build();
             return client.genericKubernetesResources(context).inNamespace(namespace).resource(generic).serverSideApply();
         }
         return client.resource(resource).inNamespace(namespace).unlock().serverSideApply();
+    }
+
+    private static String parseGroup(String apiVersion) {
+        if (apiVersion != null && apiVersion.contains("/")) {
+            return apiVersion.split("/", 2)[0];
+        }
+        return "";
+    }
+
+    private static String parseVersion(String apiVersion) {
+        if (apiVersion != null && apiVersion.contains("/")) {
+            return apiVersion.split("/", 2)[1];
+        }
+        return apiVersion != null ? apiVersion : "";
     }
 
     @Getter

--- a/src/main/java/io/kestra/plugin/kubernetes/kubectl/Apply.java
+++ b/src/main/java/io/kestra/plugin/kubernetes/kubectl/Apply.java
@@ -267,15 +267,26 @@ public class Apply extends AbstractPod implements RunnableTask<Apply.Output> {
 
     private static HasMetadata applyResource(KubernetesClient client, HasMetadata resource, String namespace) {
         if (resource instanceof GenericKubernetesResource generic) {
+            // KubernetesSerialization.unmarshal() returns GenericKubernetesResource for CRDs and unknown kinds.
+            // Use metadata.namespace to detect cluster-scoped resources (Namespace, PersistentVolume, Node, ClusterRole, etc.):
+            // cluster-scoped specs have no namespace in their metadata, so calling .inNamespace() would route to the wrong API path.
+            var resourceNamespace = generic.getMetadata().getNamespace();
+            var isNamespaced = resourceNamespace != null;
             var apiVersion = generic.getApiVersion();
             var context = new ResourceDefinitionContext.Builder()
                 .withGroup(parseGroup(apiVersion))
                 .withVersion(parseVersion(apiVersion))
                 .withKind(generic.getKind())
-                .withNamespaced(true) // Assuming resources are namespaced as we take namespace input
+                .withNamespaced(isNamespaced)
                 .build();
-            return client.genericKubernetesResources(context).inNamespace(namespace).resource(generic).serverSideApply();
+            var resourceClient = client.genericKubernetesResources(context);
+            return isNamespaced
+                ? resourceClient.inNamespace(resourceNamespace).resource(generic).serverSideApply()
+                : resourceClient.resource(generic).serverSideApply();
         }
+
+        // KubernetesSerialization.unmarshal() returns typed HasMetadata (Deployment, Service, ConfigMap, ...) for known built-in kinds.
+        // These are always namespaced; use the task-level namespace since specs typically omit metadata.namespace.
         return client.resource(resource).inNamespace(namespace).unlock().serverSideApply();
     }
 

--- a/src/main/java/io/kestra/plugin/kubernetes/kubectl/Apply.java
+++ b/src/main/java/io/kestra/plugin/kubernetes/kubectl/Apply.java
@@ -241,16 +241,18 @@ public class Apply extends AbstractPod implements RunnableTask<Apply.Output> {
                         var resourceName = resourceMetadata.getName();
                         var apiVersion = hasMetadata.getApiVersion();
                         var kind = hasMetadata.getKind();
+                        var isNamespaced = resourceMetadata.getNamespace() != null;
 
                         var resourceContext = new ResourceDefinitionContext.Builder()
                             .withGroup(parseGroup(apiVersion))
                             .withVersion(parseVersion(apiVersion))
                             .withKind(kind)
-                            .withNamespaced(true)
+                            .withNamespaced(isNamespaced)
                             .build();
 
+                        var waitNamespace = isNamespaced ? resourceMetadata.getNamespace() : rNamespace;
                         logger.info("Waiting for resource '{}' to become ready (timeout: {})...", resourceName, rWaitUntilReady);
-                        ResourceWaitService.waitForReady(client, resourceContext, rNamespace, resourceName, rWaitUntilReady, logger);
+                        ResourceWaitService.waitForReady(client, resourceContext, waitNamespace, resourceName, rWaitUntilReady, logger);
                         logger.info("Resource '{}' is ready", resourceName);
                     }
                 } catch (Exception exception) {
@@ -268,8 +270,7 @@ public class Apply extends AbstractPod implements RunnableTask<Apply.Output> {
     private static HasMetadata applyResource(KubernetesClient client, HasMetadata resource, String namespace) {
         if (resource instanceof GenericKubernetesResource generic) {
             // KubernetesSerialization.unmarshal() returns GenericKubernetesResource for CRDs and unknown kinds.
-            // Use metadata.namespace to detect cluster-scoped resources (Namespace, PersistentVolume, Node, ClusterRole, etc.):
-            // cluster-scoped specs have no namespace in their metadata, so calling .inNamespace() would route to the wrong API path.
+            // Cluster-scoped specs have no namespace in their metadata, so calling .inNamespace() would route to the wrong API path.
             var resourceNamespace = generic.getMetadata().getNamespace();
             var isNamespaced = resourceNamespace != null;
             var apiVersion = generic.getApiVersion();
@@ -286,7 +287,7 @@ public class Apply extends AbstractPod implements RunnableTask<Apply.Output> {
         }
 
         // KubernetesSerialization.unmarshal() returns typed HasMetadata (Deployment, Service, ConfigMap, ...) for known built-in kinds.
-        // These are always namespaced; use the task-level namespace since specs typically omit metadata.namespace.
+        // Typed HasMetadata objects use the task-level namespace since specs typically omit metadata.namespace.
         return client.resource(resource).inNamespace(namespace).unlock().serverSideApply();
     }
 

--- a/src/test/java/io/kestra/plugin/kubernetes/kubectl/ApplyTest.java
+++ b/src/test/java/io/kestra/plugin/kubernetes/kubectl/ApplyTest.java
@@ -74,6 +74,68 @@ class ApplyTest {
     }
 
     @Test
+    void runCoreGroupService() throws Exception {
+        var runContext = runContextFactory.of();
+
+        var task = Apply.builder()
+            .id(Apply.class.getSimpleName())
+            .type(Apply.class.getName())
+            .namespace(Property.ofValue("default"))
+            .spec(
+                Property.ofValue(
+                    """
+                        apiVersion: v1
+                        kind: Service
+                        metadata:
+                          name: my-test-service
+                        spec:
+                          selector:
+                            app: myapp
+                          ports:
+                            - protocol: TCP
+                              port: 80
+                              targetPort: 8080
+                        """
+                )
+            )
+            .build();
+
+        var runOutput = task.run(runContext);
+
+        assertThat(runOutput.getMetadata(), notNullValue());
+        assertThat(runOutput.getMetadata().getFirst().getName(), is("my-test-service"));
+    }
+
+    @Test
+    void runCoreGroupConfigMap() throws Exception {
+        var runContext = runContextFactory.of();
+
+        var task = Apply.builder()
+            .id(Apply.class.getSimpleName())
+            .type(Apply.class.getName())
+            .namespace(Property.ofValue("default"))
+            .spec(
+                Property.ofValue(
+                    """
+                        apiVersion: v1
+                        kind: ConfigMap
+                        metadata:
+                          name: my-test-configmap
+                        data:
+                          key1: value1
+                          key2: value2
+                        """
+                )
+            )
+            .build();
+
+        var runOutput = task.run(runContext);
+
+        assertThat(runOutput.getMetadata(), notNullValue());
+        assertThat(runOutput.getMetadata().getFirst().getName(), is("my-test-configmap"));
+    }
+
+    @Test
     void runWithWaitUntilReadyZero() throws Exception {
         // Test that waitUntilReady with PT0S returns immediately without waiting for pod to be ready
         var runContext = runContextFactory.of();

--- a/src/test/java/io/kestra/plugin/kubernetes/kubectl/ApplyTest.java
+++ b/src/test/java/io/kestra/plugin/kubernetes/kubectl/ApplyTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.parallel.ResourceLock;
 import io.kestra.core.junit.annotations.KestraTest;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.runners.RunContextFactory;
+import io.kestra.core.utils.IdUtils;
 
 import jakarta.inject.Inject;
 import lombok.extern.slf4j.Slf4j;
@@ -78,7 +79,7 @@ class ApplyTest {
         var runContext = runContextFactory.of();
 
         var task = Apply.builder()
-            .id(Apply.class.getSimpleName())
+            .id(IdUtils.create())
             .type(Apply.class.getName())
             .namespace(Property.ofValue("default"))
             .spec(
@@ -111,7 +112,7 @@ class ApplyTest {
         var runContext = runContextFactory.of();
 
         var task = Apply.builder()
-            .id(Apply.class.getSimpleName())
+            .id(IdUtils.create())
             .type(Apply.class.getName())
             .namespace(Property.ofValue("default"))
             .spec(


### PR DESCRIPTION
## Summary

- `kubectl.Apply` failed for core API group resources (`apiVersion: v1`) because Fabric8's `client.resource()` cannot route a `GenericKubernetesResource` to `/api/v1/...` — it only handles named API groups (`/apis/<group>/...`)
- Added a private `applyResource()` helper in `Apply.java` that checks `instanceof GenericKubernetesResource`: if true, builds a `ResourceDefinitionContext` (parsing the empty group from `apiVersion`) and calls `client.genericKubernetesResources(context).inNamespace(...).resource(...).serverSideApply()` — the same pattern already used in `Delete.java`, `Get.java`, and `Patch.java`
- Typed `HasMetadata` resources (e.g., `Deployment` from `apps/v1`) continue through the existing `client.resource().inNamespace().unlock().serverSideApply()` path unchanged
- Added integration tests for `v1/Service` and `v1/ConfigMap`, and a `v1/Service` example in `@Plugin` examples

closes: https://github.com/kestra-io/plugin-kubernetes/issues/294

## Test plan

- [x] `./gradlew cleanTest test --tests "io.kestra.plugin.kubernetes.kubectl.ApplyTest"` passes (all 5 tests including `runCoreGroupService` and `runCoreGroupConfigMap`)
- [ ] `./gradlew shadowJar` builds
- [ ] Manual: apply a `v1/Service` and `v1/ConfigMap` manifest via `kubectl.Apply` in a live cluster