### PR TITLE
fix(apply): restore namespaced URL for named-group resources

### DIFF
--- a/src/main/java/io/kestra/plugin/kubernetes/kubectl/Apply.java
+++ b/src/main/java/io/kestra/plugin/kubernetes/kubectl/Apply.java
@@ -268,26 +268,28 @@ public class Apply extends AbstractPod implements RunnableTask<Apply.Output> {
     }
 
     private static HasMetadata applyResource(KubernetesClient client, HasMetadata resource, String namespace) {
-        if (resource instanceof GenericKubernetesResource generic) {
-            // KubernetesSerialization.unmarshal() returns GenericKubernetesResource for CRDs and unknown kinds.
-            // Cluster-scoped specs have no namespace in their metadata, so calling .inNamespace() would route to the wrong API path.
-            var resourceNamespace = generic.getMetadata().getNamespace();
-            var isNamespaced = resourceNamespace != null;
-            var apiVersion = generic.getApiVersion();
+        if (resource instanceof GenericKubernetesResource generic && parseGroup(generic.getApiVersion()).isEmpty()) {
+            // Core-group v1 resources (Service, ConfigMap, Pod, ...) must go through genericKubernetesResources()
+            // because Fabric8 routes them through /api/v1/... not /apis/.
+            // Named-group resources (apps/v1 Deployment, etc.) fall through to client.resource() below even when
+            // unmarshal() returns GenericKubernetesResource, since client.resource() correctly uses /apis/<group>/...
+            var effectiveNamespace = generic.getMetadata().getNamespace() != null
+                ? generic.getMetadata().getNamespace()
+                : namespace;
             var context = new ResourceDefinitionContext.Builder()
-                .withGroup(parseGroup(apiVersion))
-                .withVersion(parseVersion(apiVersion))
+                .withGroup("")
+                .withVersion(parseVersion(generic.getApiVersion()))
                 .withKind(generic.getKind())
-                .withNamespaced(isNamespaced)
+                .withNamespaced(true)
                 .build();
-            var resourceClient = client.genericKubernetesResources(context);
-            return isNamespaced
-                ? resourceClient.inNamespace(resourceNamespace).resource(generic).serverSideApply()
-                : resourceClient.resource(generic).serverSideApply();
+            return client.genericKubernetesResources(context)
+                .inNamespace(effectiveNamespace)
+                .resource(generic)
+                .serverSideApply();
         }
 
-        // KubernetesSerialization.unmarshal() returns typed HasMetadata (Deployment, Service, ConfigMap, ...) for known built-in kinds.
-        // Typed HasMetadata objects use the task-level namespace since specs typically omit metadata.namespace.
+        // Named-group resources (apps/v1 etc.) and typed HasMetadata objects both go here.
+        // Specs typically omit metadata.namespace, so we use the task-level namespace.
         return client.resource(resource).inNamespace(namespace).unlock().serverSideApply();
     }
 

--- a/src/test/java/io/kestra/plugin/kubernetes/kubectl/ApplyTest.java
+++ b/src/test/java/io/kestra/plugin/kubernetes/kubectl/ApplyTest.java
@@ -75,6 +75,51 @@ class ApplyTest {
     }
 
     @Test
+    void runNamedGroupDeployment() throws Exception {
+        // Regression test: apps/v1 Deployment must use the namespaced URL (/apis/apps/v1/namespaces/.../deployments),
+        // not the cluster-scope one — which would produce "forbidden: ... at the cluster scope".
+        var runContext = runContextFactory.of();
+
+        var task = Apply.builder()
+            .id(IdUtils.create())
+            .type(Apply.class.getName())
+            .namespace(Property.ofValue("default"))
+            .spec(
+                Property.ofValue(
+                    """
+                        apiVersion: apps/v1
+                        kind: Deployment
+                        metadata:
+                          name: regression-named-group-deployment
+                          labels:
+                            app: regression-test
+                        spec:
+                          replicas: 1
+                          selector:
+                            matchLabels:
+                              app: regression-test
+                          template:
+                            metadata:
+                              labels:
+                                app: regression-test
+                            spec:
+                              containers:
+                              - name: app
+                                image: nginx:stable-alpine
+                                ports:
+                                - containerPort: 80
+                        """
+                )
+            )
+            .build();
+
+        var runOutput = task.run(runContext);
+
+        assertThat(runOutput.getMetadata(), notNullValue());
+        assertThat(runOutput.getMetadata().getFirst().getName(), is("regression-named-group-deployment"));
+    }
+
+    @Test
     void runCoreGroupService() throws Exception {
         var runContext = runContextFactory.of();
 


### PR DESCRIPTION
## Summary

- Narrows the `genericKubernetesResources()` path to core-group v1 resources only by adding `&& parseGroup(generic.getApiVersion()).isEmpty()` to the guard condition
- Named-group resources (`apps/v1 Deployment`, `batch/v1 Job`, etc.) now fall through to `client.resource().inNamespace(namespace).unlock().serverSideApply()`, which correctly uses `/apis/<group>/namespaces/.../...`
- `effectiveNamespace` falls back to the task-level namespace when `metadata.namespace` is absent in the manifest — consistent with `Delete.java`'s pattern

## Regression context

PR #295 fixed core-group v1 resources (Service, ConfigMap) by routing `GenericKubernetesResource` through `genericKubernetesResources()`. However, `KubernetesSerialization.unmarshal()` returns `GenericKubernetesResource` for **all** resources (not only unknown/CRD ones), so `apps/v1 Deployment` was caught by the same branch. Since manifests typically omit `metadata.namespace`, `isNamespaced` resolved to `false`, triggering a cluster-scope PATCH and the error:

```
deployments.apps "python-app" is forbidden: User cannot patch resource "deployments" in API group "apps" at the cluster scope
```

## Test plan

- [x] `rtk test ./gradlew test` passes (all existing tests green, new regression test added)
- [ ] `./gradlew shadowJar` builds
- [ ] Manual: apply `apps/v1 Deployment` manifest via the task → succeeds with namespaced URL
- [ ] Manual: apply `v1 Service` or `v1 ConfigMap` manifest → still succeeds (original fix preserved)

Fixes: https://github.com/kestra-io/plugin-kubernetes/issues/294