### PR TITLE
fix(security): remediate OWASP/CWE audit findings (2026-06-30)

### DIFF
--- a/src/main/java/io/kestra/plugin/kubernetes/models/Connection.java
+++ b/src/main/java/io/kestra/plugin/kubernetes/models/Connection.java
@@ -88,7 +88,7 @@ public class Connection {
         title = "Client key data",
         description = "Base64-encoded client key. Whitespace is stripped automatically."
     )
-    @PluginProperty(group = "advanced")
+    @PluginProperty(secret = true, group = "advanced")
     private final Property<String> clientKeyData;
 
     @Schema(
@@ -157,11 +157,19 @@ public class Connection {
         ConfigBuilder builder = new ConfigBuilder(Config.empty());
 
         if (trustCerts != null) {
-            builder.withTrustCerts(runContext.render(trustCerts).as(Boolean.class).orElseThrow());
+            boolean trustCertsValue = runContext.render(trustCerts).as(Boolean.class).orElseThrow();
+            if (trustCertsValue) {
+                runContext.logger().warn("Kubernetes connection is configured with trustCerts=true: TLS certificate validation is disabled. This should only be used for testing, never in production.");
+            }
+            builder.withTrustCerts(trustCertsValue);
         }
 
         if (disableHostnameVerification != null) {
-            builder.withDisableHostnameVerification(runContext.render(disableHostnameVerification).as(Boolean.class).orElseThrow());
+            boolean disableHostnameVerificationValue = runContext.render(disableHostnameVerification).as(Boolean.class).orElseThrow();
+            if (disableHostnameVerificationValue) {
+                runContext.logger().warn("Kubernetes connection is configured with disableHostnameVerification=true: TLS hostname checks are disabled. Avoid this in production clusters.");
+            }
+            builder.withDisableHostnameVerification(disableHostnameVerificationValue);
         }
 
         if (masterUrl != null) {


### PR DESCRIPTION
## Summary

Remediates all findings (CRITICAL/HIGH/MEDIUM/LOW) from the 2026-06-30 automated security audit against OWASP Top 10 (2025), CWE Top 25, and OWASP ASVS Level 1.

## Findings Fixed

- **HIGH** — `clientKeyData` field missing `@PluginProperty(secret=true)` — `src/main/java/io/kestra/plugin/kubernetes/models/Connection.java:92` — Added `secret = true` to the `@PluginProperty` annotation so the base64-encoded TLS client private key is treated as a secret (no longer logged or rendered in plaintext in task inputs/outputs/UI), matching the treatment already applied to `clientKeyPassphrase`, `oauthToken`, `password`, and the keystore/truststore passphrases.
- **MEDIUM** — User-controllable TLS bypass flags (`trustCerts`, `disableHostnameVerification`) lack runtime guard — `src/main/java/io/kestra/plugin/kubernetes/models/Connection.java:22` — Added a runtime warning log (via `runContext.logger().warn(...)`) emitted whenever `trustCerts=true` or `disableHostnameVerification=true` is used, so insecure TLS configurations are visible in execution logs instead of silently bypassing certificate/hostname validation.

## Testing

- [ ] `./gradlew build` passes
- [ ] No regressions in existing tests

## References

- Security Audit EPIC: https://github.com/kestra-io/plugin-kubernetes/issues/311
- [Full Audit Report](https://claude.ai/code/artifact/87ba8c38-c7ec-40ef-8d8e-384da1bfacf4)
- [Org-wide Security Meta-EPIC](https://github.com/kestra-io/kestra-ee/issues/9092)
