### PR TITLE
fix: resume pods across attempts and clean up stale ones on resubmit

### DIFF
--- a/src/main/java/io/kestra/plugin/kubernetes/core/PodCreate.java
+++ b/src/main/java/io/kestra/plugin/kubernetes/core/PodCreate.java
@@ -292,7 +292,7 @@ public class PodCreate extends AbstractPod implements RunnableTask<PodCreate.Out
 
     @Schema(
         title = "Resume an existing pod when possible",
-        description = "Default true. Reconnects to a pod labeled with the current taskrun ID, whatever attempt created it. Stale pods from previous attempts are deleted."
+        description = "Default true. Reconnects to a pod labeled with the current taskrun ID, whatever attempt created it. Stale pods from previous attempts are deleted. Still-active stale pods are removed even when `delete` is false, to protect quotas and concurrency limits."
     )
     @NotNull
     @Builder.Default
@@ -567,22 +567,30 @@ public class PodCreate extends AbstractPod implements RunnableTask<PodCreate.Out
                 .getItems();
 
             // Resume the most recent pod that can still deliver a result
-            Pod resumed = existingPods.stream()
+            var resumed = existingPods.stream()
                 .filter(PodCreate::isResumable)
                 .max(Comparator.comparing(
-                    p -> p.getMetadata().getCreationTimestamp(),
+                    (Pod p) -> p.getMetadata().getCreationTimestamp(),
                     Comparator.nullsFirst(Comparator.naturalOrder())
-                ))
+                ).thenComparing(p -> p.getMetadata().getName()))
                 .orElse(null);
 
-            // Delete stale pods so a previous attempt cannot break quotas or concurrency limits
+            // Delete stale pods so a previous attempt cannot break quotas or concurrency limits.
+            // Active ones are always removed; terminal ones follow the `delete` property so
+            // `delete=false` still keeps them for debugging.
+            boolean deleteEnabled = runContext.render(this.delete).as(Boolean.class).orElse(true);
             for (Pod other : existingPods) {
-                if (other != resumed && isActive(other)) {
+                if (other != resumed && (isActive(other) || deleteEnabled)) {
                     logger.warn(
                         "Deleting stale pod '{}' left behind by a previous attempt of taskrun '{}'",
                         other.getMetadata().getName(), taskrunId
                     );
-                    PodService.podRef(client, other).delete();
+                    try {
+                        PodService.podRef(client, other).delete();
+                    } catch (Exception e) {
+                        // Best-effort cleanup: never abort the run because a stale pod would not go away
+                        logger.warn("Unable to delete stale pod '{}'", other.getMetadata().getName(), e);
+                    }
                 }
             }
 

--- a/src/main/java/io/kestra/plugin/kubernetes/core/PodCreate.java
+++ b/src/main/java/io/kestra/plugin/kubernetes/core/PodCreate.java
@@ -578,9 +578,9 @@ public class PodCreate extends AbstractPod implements RunnableTask<PodCreate.Out
             // Delete stale pods so a previous attempt cannot break quotas or concurrency limits.
             // Active ones are always removed; terminal ones follow the `delete` property so
             // `delete=false` still keeps them for debugging.
-            boolean deleteEnabled = runContext.render(this.delete).as(Boolean.class).orElse(true);
+            boolean rDelete = runContext.render(this.delete).as(Boolean.class).orElse(true);
             for (Pod other : existingPods) {
-                if (other != resumed && (isActive(other) || deleteEnabled)) {
+                if (other != resumed && (isActive(other) || rDelete)) {
                     logger.warn(
                         "Deleting stale pod '{}' left behind by a previous attempt of taskrun '{}'",
                         other.getMetadata().getName(), taskrunId

--- a/src/main/java/io/kestra/plugin/kubernetes/core/PodCreate.java
+++ b/src/main/java/io/kestra/plugin/kubernetes/core/PodCreate.java
@@ -292,7 +292,7 @@ public class PodCreate extends AbstractPod implements RunnableTask<PodCreate.Out
 
     @Schema(
         title = "Resume an existing pod when possible",
-        description = "Default true. Reconnects to a pod labeled with the current taskrun ID (whatever attempt created it) instead of creating a new one. Stale pods from previous attempts are deleted, and a new pod is created when no resumable one exists."
+        description = "Default true. Reconnects to a pod labeled with the current taskrun ID, whatever attempt created it. Stale pods from previous attempts are deleted."
     )
     @NotNull
     @Builder.Default
@@ -534,11 +534,9 @@ public class PodCreate extends AbstractPod implements RunnableTask<PodCreate.Out
      * Finds an existing pod to resume or creates a new pod.
      *
      * <p>
-     * When {@code resume=true}, this method searches for existing pods matching the current
-     * taskrun ID. The attempt count is deliberately not part of the selector, so a RESUBMITTED
-     * task (higher attempt count after a worker crash) still reconnects to the previous attempt's
-     * pod (see issue #249). The most recent resumable pod is returned; other non-terminal pods of
-     * the same taskrun are deleted to protect quotas, and a new pod is created when none is resumable.
+     * When {@code resume=true}, resumes the most recent resumable pod matching the taskrun ID,
+     * whatever attempt created it (so a RESUBMITTED task reconnects, see issue #249). Other
+     * non-terminal pods of the taskrun are deleted. Creates a new pod when none is resumable.
      *
      * @param runContext execution context for rendering properties and accessing variables
      * @param client Kubernetes client for pod operations
@@ -555,10 +553,8 @@ public class PodCreate extends AbstractPod implements RunnableTask<PodCreate.Out
         Map<String, Object> additionalVars,
         Logger logger) throws Exception {
         if (runContext.render(this.resume).as(Boolean.class).orElseThrow()) {
-            // Locate existing pods for this taskrun, whatever attempt created them. The attempt
-            // count is deliberately not part of the selector: a task RESUBMITTED after a worker
-            // crash runs with a higher attempt count and must still reconnect to the previous
-            // attempt's pod instead of leaving it orphaned (see issue #249).
+            // No attempt count in the selector: a RESUBMITTED task runs with a higher attempt
+            // count and must still find the previous attempt's pod (see issue #249).
             // Safe cast: runContext.getVariables() returns Map<String, Object> where "taskrun" is always a Map
             @SuppressWarnings("unchecked")
             Map<String, Object> taskrun = (Map<String, Object>) runContext.getVariables().get("taskrun");
@@ -579,8 +575,7 @@ public class PodCreate extends AbstractPod implements RunnableTask<PodCreate.Out
                 ))
                 .orElse(null);
 
-            // Delete every other pod of this taskrun that could still consume resources,
-            // so a stale previous attempt cannot break quotas or concurrency limits
+            // Delete stale pods so a previous attempt cannot break quotas or concurrency limits
             for (Pod other : existingPods) {
                 if (other != resumed && isActive(other)) {
                     logger.warn(
@@ -604,8 +599,7 @@ public class PodCreate extends AbstractPod implements RunnableTask<PodCreate.Out
     }
 
     /**
-     * A pod can be resumed when it can still deliver a result: not yet started, running,
-     * or completed successfully (logs and output files remain collectable).
+     * A pod is resumable while it can still deliver a result: Pending, Running, or Succeeded.
      */
     private static boolean isResumable(Pod pod) {
         if (pod.getStatus() == null || pod.getStatus().getPhase() == null) {
@@ -618,9 +612,7 @@ public class PodCreate extends AbstractPod implements RunnableTask<PodCreate.Out
     }
 
     /**
-     * A pod is still active (consuming or about to consume cluster resources) unless it
-     * reached a terminal phase. Unknown or missing status counts as active so cleanup errs
-     * on the side of protecting quotas.
+     * A pod is active until it reaches a terminal phase. Unknown or missing status counts as active.
      */
     private static boolean isActive(Pod pod) {
         if (pod.getStatus() == null || pod.getStatus().getPhase() == null) {

--- a/src/main/java/io/kestra/plugin/kubernetes/core/PodCreate.java
+++ b/src/main/java/io/kestra/plugin/kubernetes/core/PodCreate.java
@@ -293,7 +293,7 @@ public class PodCreate extends AbstractPod implements RunnableTask<PodCreate.Out
 
     @Schema(
         title = "Resume an existing pod when possible",
-        description = "Default true. Reconnects to a pod labeled with the current taskrun ID, whatever attempt created it. Stale pods from previous attempts are deleted. Still-active stale pods are removed even when `delete` is false, to protect quotas and concurrency limits."
+        description = "Default true. Reconnects to a pod labeled with the current taskrun ID, whatever attempt created it. A completed (Succeeded) pod is only resumed within the same attempt, so task retries re-run the workload. Stale pods from previous attempts are deleted. Still-active stale pods are removed even when `delete` is false, to protect quotas and concurrency limits."
     )
     @NotNull
     @Builder.Default
@@ -558,6 +558,7 @@ public class PodCreate extends AbstractPod implements RunnableTask<PodCreate.Out
             @SuppressWarnings("unchecked")
             Map<String, Object> taskrun = (Map<String, Object>) runContext.getVariables().get("taskrun");
             String taskrunId = ScriptService.normalize(String.valueOf(taskrun.get("id")));
+            String attempt = ScriptService.normalize(String.valueOf(taskrun.get("attemptsCount")));
             String labelSelector = "kestra.io/taskrun-id=" + taskrunId;
 
             var existingPods = client.pods()
@@ -565,9 +566,10 @@ public class PodCreate extends AbstractPod implements RunnableTask<PodCreate.Out
                 .list(new ListOptionsBuilder().withLabelSelector(labelSelector).build())
                 .getItems();
 
+            // creationTimestamp has 1-second granularity; equal stamps fall back to name, which is arbitrary
             Comparator<Pod> byPriority = Comparator.comparingInt(PodCreate::resumePriority);
             var resumed = existingPods.stream()
-                .filter(PodCreate::isResumable)
+                .filter(p -> isResumableForAttempt(p, attempt))
                 .max(byPriority
                     .thenComparing(p -> p.getMetadata().getCreationTimestamp(), Comparator.nullsFirst(Comparator.naturalOrder()))
                     .thenComparing(p -> p.getMetadata().getName()))
@@ -639,6 +641,24 @@ public class PodCreate extends AbstractPod implements RunnableTask<PodCreate.Out
             && !PodService.PodPhase.FAILED.value().equals(phase);
     }
 
+    /**
+     * Cross-attempt resume is what lets a RESUBMITTED task reconnect (issue #249), but a Succeeded
+     * pod is only reused within the same attempt: task-level retries bump the attempt count too,
+     * and resuming the completed pod would turn the retry into a no-op.
+     */
+    static boolean isResumableForAttempt(Pod pod, String attempt) {
+        if (!isResumable(pod)) {
+            return false;
+        }
+        if (!PodService.PodPhase.SUCCEEDED.value().equals(pod.getStatus().getPhase())) {
+            return true;
+        }
+        String podAttempt = pod.getMetadata() != null && pod.getMetadata().getLabels() != null
+            ? pod.getMetadata().getLabels().get("kestra.io/taskrun-attempt")
+            : null;
+        return attempt.equals(podAttempt);
+    }
+
     private static boolean isTerminating(Pod pod) {
         return pod.getMetadata() != null && pod.getMetadata().getDeletionTimestamp() != null;
     }
@@ -647,6 +667,9 @@ public class PodCreate extends AbstractPod implements RunnableTask<PodCreate.Out
      * Succeeded outranks Running outranks Pending: a completed pod already holds the taskrun's result.
      */
     static int resumePriority(Pod pod) {
+        if (pod.getStatus() == null || pod.getStatus().getPhase() == null) {
+            return 0;
+        }
         String phase = pod.getStatus().getPhase();
         if (PodService.PodPhase.SUCCEEDED.value().equals(phase)) {
             return 3;

--- a/src/main/java/io/kestra/plugin/kubernetes/core/PodCreate.java
+++ b/src/main/java/io/kestra/plugin/kubernetes/core/PodCreate.java
@@ -73,9 +73,10 @@ import static io.kestra.plugin.kubernetes.shared.services.PodService.waitForComp
  * </ul>
  *
  * <h2>Resume Behavior</h2>
- * When {@code resume=true} (default), the task attempts to reconnect to an existing pod with matching
- * {@code kestra.io/taskrun-id} and {@code kestra.io/taskrun-attempt} labels. This allows recovery from
- * interrupted executions without restarting the pod. If no matching pod exists, a new one is created.
+ * When {@code resume=true} (default), the task attempts to reconnect to an existing pod with a matching
+ * {@code kestra.io/taskrun-id} label, whatever attempt created it. This allows recovery from
+ * interrupted executions (including RESUBMITTED tasks after a worker crash) without restarting the pod.
+ * Stale non-terminal pods from previous attempts are deleted, and a new pod is created when none is resumable.
  *
  * <h2>Pod Lifecycle</h2>
  * <ol>
@@ -291,7 +292,7 @@ public class PodCreate extends AbstractPod implements RunnableTask<PodCreate.Out
 
     @Schema(
         title = "Resume an existing pod when possible",
-        description = "Default true. Reconnects to a pod labeled with the current taskrun ID and attempt instead of creating a new one; falls back to a new pod if none or multiple matches exist."
+        description = "Default true. Reconnects to a pod labeled with the current taskrun ID (whatever attempt created it) instead of creating a new one. Stale pods from previous attempts are deleted, and a new pod is created when no resumable one exists."
     )
     @NotNull
     @Builder.Default
@@ -533,9 +534,11 @@ public class PodCreate extends AbstractPod implements RunnableTask<PodCreate.Out
      * Finds an existing pod to resume or creates a new pod.
      *
      * <p>
-     * When {@code resume=true}, this method searches for an existing pod matching the current
-     * taskrun ID and attempt count. If exactly one matching pod is found, it is returned for resumption.
-     * If no pod or multiple pods are found, a new pod is created.
+     * When {@code resume=true}, this method searches for existing pods matching the current
+     * taskrun ID. The attempt count is deliberately not part of the selector, so a RESUBMITTED
+     * task (higher attempt count after a worker crash) still reconnects to the previous attempt's
+     * pod (see issue #249). The most recent resumable pod is returned; other non-terminal pods of
+     * the same taskrun are deleted to protect quotas, and a new pod is created when none is resumable.
      *
      * @param runContext execution context for rendering properties and accessing variables
      * @param client Kubernetes client for pod operations
@@ -552,24 +555,45 @@ public class PodCreate extends AbstractPod implements RunnableTask<PodCreate.Out
         Map<String, Object> additionalVars,
         Logger logger) throws Exception {
         if (runContext.render(this.resume).as(Boolean.class).orElseThrow()) {
-            // Try to locate an existing pod for this taskrun and attempt
+            // Locate existing pods for this taskrun, whatever attempt created them. The attempt
+            // count is deliberately not part of the selector: a task RESUBMITTED after a worker
+            // crash runs with a higher attempt count and must still reconnect to the previous
+            // attempt's pod instead of leaving it orphaned (see issue #249).
             // Safe cast: runContext.getVariables() returns Map<String, Object> where "taskrun" is always a Map
             @SuppressWarnings("unchecked")
             Map<String, Object> taskrun = (Map<String, Object>) runContext.getVariables().get("taskrun");
             String taskrunId = ScriptService.normalize(String.valueOf(taskrun.get("id")));
-            String attempt = ScriptService.normalize(String.valueOf(taskrun.get("attemptsCount")));
-            String labelSelector = "kestra.io/taskrun-id=" + taskrunId + "," + "kestra.io/taskrun-attempt=" + attempt;
+            String labelSelector = "kestra.io/taskrun-id=" + taskrunId;
 
             var existingPods = client.pods()
                 .inNamespace(namespace)
-                .list(new ListOptionsBuilder().withLabelSelector(labelSelector).build());
+                .list(new ListOptionsBuilder().withLabelSelector(labelSelector).build())
+                .getItems();
 
-            if (existingPods.getItems().size() == 1) {
-                Pod pod = existingPods.getItems().get(0);
-                logger.info("Pod '{}' is resumed from an already running pod", pod.getMetadata().getName());
-                return pod;
-            } else if (!existingPods.getItems().isEmpty()) {
-                logger.warn("More than one pod exists for the label selector {}, no pods will be resumed.", labelSelector);
+            // Resume the most recent pod that can still deliver a result
+            Pod resumed = existingPods.stream()
+                .filter(PodCreate::isResumable)
+                .max(Comparator.comparing(
+                    p -> p.getMetadata().getCreationTimestamp(),
+                    Comparator.nullsFirst(Comparator.naturalOrder())
+                ))
+                .orElse(null);
+
+            // Delete every other pod of this taskrun that could still consume resources,
+            // so a stale previous attempt cannot break quotas or concurrency limits
+            for (Pod other : existingPods) {
+                if (other != resumed && isActive(other)) {
+                    logger.warn(
+                        "Deleting stale pod '{}' left behind by a previous attempt of taskrun '{}'",
+                        other.getMetadata().getName(), taskrunId
+                    );
+                    PodService.podRef(client, other).delete();
+                }
+            }
+
+            if (resumed != null) {
+                logger.info("Pod '{}' is resumed from an already running pod", resumed.getMetadata().getName());
+                return resumed;
             }
         }
 
@@ -577,6 +601,34 @@ public class PodCreate extends AbstractPod implements RunnableTask<PodCreate.Out
         Pod pod = createPod(runContext, client, namespace, additionalVars);
         logger.info("Pod '{}' is created", pod.getMetadata().getName());
         return pod;
+    }
+
+    /**
+     * A pod can be resumed when it can still deliver a result: not yet started, running,
+     * or completed successfully (logs and output files remain collectable).
+     */
+    private static boolean isResumable(Pod pod) {
+        if (pod.getStatus() == null || pod.getStatus().getPhase() == null) {
+            return false;
+        }
+        String phase = pod.getStatus().getPhase();
+        return PodService.PodPhase.PENDING.value().equals(phase)
+            || PodService.PodPhase.RUNNING.value().equals(phase)
+            || PodService.PodPhase.SUCCEEDED.value().equals(phase);
+    }
+
+    /**
+     * A pod is still active (consuming or about to consume cluster resources) unless it
+     * reached a terminal phase. Unknown or missing status counts as active so cleanup errs
+     * on the side of protecting quotas.
+     */
+    private static boolean isActive(Pod pod) {
+        if (pod.getStatus() == null || pod.getStatus().getPhase() == null) {
+            return true;
+        }
+        String phase = pod.getStatus().getPhase();
+        return !PodService.PodPhase.SUCCEEDED.value().equals(phase)
+            && !PodService.PodPhase.FAILED.value().equals(phase);
     }
 
     /**

--- a/src/main/java/io/kestra/plugin/kubernetes/core/PodCreate.java
+++ b/src/main/java/io/kestra/plugin/kubernetes/core/PodCreate.java
@@ -554,8 +554,6 @@ public class PodCreate extends AbstractPod implements RunnableTask<PodCreate.Out
         Map<String, Object> additionalVars,
         Logger logger) throws Exception {
         if (runContext.render(this.resume).as(Boolean.class).orElseThrow()) {
-            // No attempt count in the selector: a RESUBMITTED task runs with a higher attempt
-            // count and must still find the previous attempt's pod (see issue #249).
             // Safe cast: runContext.getVariables() returns Map<String, Object> where "taskrun" is always a Map
             @SuppressWarnings("unchecked")
             Map<String, Object> taskrun = (Map<String, Object>) runContext.getVariables().get("taskrun");
@@ -567,8 +565,6 @@ public class PodCreate extends AbstractPod implements RunnableTask<PodCreate.Out
                 .list(new ListOptionsBuilder().withLabelSelector(labelSelector).build())
                 .getItems();
 
-            // Resume the pod most likely to deliver a result: a Succeeded pod already holds it,
-            // then Running, then Pending; recency breaks ties.
             Comparator<Pod> byPriority = Comparator.comparingInt(PodCreate::resumePriority);
             var resumed = existingPods.stream()
                 .filter(PodCreate::isResumable)

--- a/src/main/java/io/kestra/plugin/kubernetes/core/PodCreate.java
+++ b/src/main/java/io/kestra/plugin/kubernetes/core/PodCreate.java
@@ -5,6 +5,7 @@ import java.net.URI;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.util.*;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
@@ -566,18 +567,21 @@ public class PodCreate extends AbstractPod implements RunnableTask<PodCreate.Out
                 .list(new ListOptionsBuilder().withLabelSelector(labelSelector).build())
                 .getItems();
 
-            // Resume the most recent pod that can still deliver a result
+            // Resume the pod most likely to deliver a result: a Succeeded pod already holds it,
+            // then Running, then Pending; recency breaks ties.
+            Comparator<Pod> byPriority = Comparator.comparingInt(PodCreate::resumePriority);
             var resumed = existingPods.stream()
                 .filter(PodCreate::isResumable)
-                .max(Comparator.comparing(
-                    (Pod p) -> p.getMetadata().getCreationTimestamp(),
-                    Comparator.nullsFirst(Comparator.naturalOrder())
-                ).thenComparing(p -> p.getMetadata().getName()))
+                .max(byPriority
+                    .thenComparing(p -> p.getMetadata().getCreationTimestamp(), Comparator.nullsFirst(Comparator.naturalOrder()))
+                    .thenComparing(p -> p.getMetadata().getName()))
                 .orElse(null);
 
             // Delete stale pods so a previous attempt cannot break quotas or concurrency limits.
             // Active ones are always removed; terminal ones follow the `delete` property so
-            // `delete=false` still keeps them for debugging.
+            // `delete=false` still keeps them for debugging. The delete waits for finalization:
+            // with a pinned metadata name, creating the replacement before the old pod is gone
+            // would fail with 409 AlreadyExists.
             boolean rDelete = runContext.render(this.delete).as(Boolean.class).orElse(true);
             for (Pod other : existingPods) {
                 if (other != resumed && (isActive(other) || rDelete)) {
@@ -586,7 +590,7 @@ public class PodCreate extends AbstractPod implements RunnableTask<PodCreate.Out
                         other.getMetadata().getName(), taskrunId
                     );
                     try {
-                        PodService.podRef(client, other).delete();
+                        PodService.podRef(client, other).withTimeout(30, TimeUnit.SECONDS).delete();
                     } catch (Exception e) {
                         // Best-effort cleanup: never abort the run because a stale pod would not go away
                         logger.warn("Unable to delete stale pod '{}'", other.getMetadata().getName(), e);
@@ -607,9 +611,13 @@ public class PodCreate extends AbstractPod implements RunnableTask<PodCreate.Out
     }
 
     /**
-     * A pod is resumable while it can still deliver a result: Pending, Running, or Succeeded.
+     * A pod is resumable while it can still deliver a result: Pending, Running, or Succeeded,
+     * and not already terminating (a deleted pod keeps its phase until finalized).
      */
-    private static boolean isResumable(Pod pod) {
+    static boolean isResumable(Pod pod) {
+        if (isTerminating(pod)) {
+            return false;
+        }
         if (pod.getStatus() == null || pod.getStatus().getPhase() == null) {
             return false;
         }
@@ -620,15 +628,37 @@ public class PodCreate extends AbstractPod implements RunnableTask<PodCreate.Out
     }
 
     /**
-     * A pod is active until it reaches a terminal phase. Unknown or missing status counts as active.
+     * A pod is active until it reaches a terminal phase or starts terminating.
+     * Unknown or missing status counts as active.
      */
-    private static boolean isActive(Pod pod) {
+    static boolean isActive(Pod pod) {
+        if (isTerminating(pod)) {
+            return false;
+        }
         if (pod.getStatus() == null || pod.getStatus().getPhase() == null) {
             return true;
         }
         String phase = pod.getStatus().getPhase();
         return !PodService.PodPhase.SUCCEEDED.value().equals(phase)
             && !PodService.PodPhase.FAILED.value().equals(phase);
+    }
+
+    private static boolean isTerminating(Pod pod) {
+        return pod.getMetadata() != null && pod.getMetadata().getDeletionTimestamp() != null;
+    }
+
+    /**
+     * Succeeded outranks Running outranks Pending: a completed pod already holds the taskrun's result.
+     */
+    static int resumePriority(Pod pod) {
+        String phase = pod.getStatus().getPhase();
+        if (PodService.PodPhase.SUCCEEDED.value().equals(phase)) {
+            return 3;
+        }
+        if (PodService.PodPhase.RUNNING.value().equals(phase)) {
+            return 2;
+        }
+        return 1;
     }
 
     /**

--- a/src/test/java/io/kestra/plugin/kubernetes/core/PodCreateResumeSelectionTest.java
+++ b/src/test/java/io/kestra/plugin/kubernetes/core/PodCreateResumeSelectionTest.java
@@ -1,0 +1,76 @@
+package io.kestra.plugin.kubernetes.core;
+
+import org.junit.jupiter.api.Test;
+
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.PodBuilder;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.is;
+
+class PodCreateResumeSelectionTest {
+
+    private Pod pod(String phase, boolean terminating) {
+        var builder = new PodBuilder()
+            .withNewMetadata()
+            .withName("selection-test");
+        if (terminating) {
+            builder = builder.withDeletionTimestamp("2026-07-23T00:00:00Z");
+        }
+        var metadataDone = builder.endMetadata();
+        if (phase == null) {
+            return metadataDone.build();
+        }
+        return metadataDone
+            .withNewStatus()
+            .withPhase(phase)
+            .endStatus()
+            .build();
+    }
+
+    @Test
+    void pendingRunningAndSucceededAreResumable() {
+        assertThat(PodCreate.isResumable(pod("Pending", false)), is(true));
+        assertThat(PodCreate.isResumable(pod("Running", false)), is(true));
+        assertThat(PodCreate.isResumable(pod("Succeeded", false)), is(true));
+    }
+
+    @Test
+    void failedUnknownAndMissingStatusAreNotResumable() {
+        assertThat(PodCreate.isResumable(pod("Failed", false)), is(false));
+        assertThat(PodCreate.isResumable(pod("Unknown", false)), is(false));
+        assertThat(PodCreate.isResumable(pod(null, false)), is(false));
+    }
+
+    @Test
+    void terminatingPodIsNeitherResumableNorActive() {
+        // A deleted pod keeps its phase until finalized - deletionTimestamp is the only signal
+        assertThat(PodCreate.isResumable(pod("Running", true)), is(false));
+        assertThat(PodCreate.isActive(pod("Running", true)), is(false));
+    }
+
+    @Test
+    void terminalPhasesAreNotActive() {
+        assertThat(PodCreate.isActive(pod("Succeeded", false)), is(false));
+        assertThat(PodCreate.isActive(pod("Failed", false)), is(false));
+    }
+
+    @Test
+    void nonTerminalAndUnknownPhasesAreActive() {
+        assertThat(PodCreate.isActive(pod("Pending", false)), is(true));
+        assertThat(PodCreate.isActive(pod("Running", false)), is(true));
+        assertThat(PodCreate.isActive(pod("Unknown", false)), is(true));
+        assertThat(PodCreate.isActive(pod(null, false)), is(true));
+    }
+
+    @Test
+    void succeededOutranksRunningOutranksPending() {
+        int succeeded = PodCreate.resumePriority(pod("Succeeded", false));
+        int running = PodCreate.resumePriority(pod("Running", false));
+        int pending = PodCreate.resumePriority(pod("Pending", false));
+
+        assertThat(succeeded, is(greaterThan(running)));
+        assertThat(running, is(greaterThan(pending)));
+    }
+}

--- a/src/test/java/io/kestra/plugin/kubernetes/core/PodCreateResumeSelectionTest.java
+++ b/src/test/java/io/kestra/plugin/kubernetes/core/PodCreateResumeSelectionTest.java
@@ -73,4 +73,30 @@ class PodCreateResumeSelectionTest {
         assertThat(succeeded, is(greaterThan(running)));
         assertThat(running, is(greaterThan(pending)));
     }
+
+    @Test
+    void missingStatusRanksLowest() {
+        assertThat(PodCreate.resumePriority(pod(null, false)), is(0));
+    }
+
+    @Test
+    void succeededPodIsOnlyResumableWithinTheSameAttempt() {
+        assertThat(PodCreate.isResumableForAttempt(podWithAttempt("Succeeded", "1"), "1"), is(true));
+        assertThat(PodCreate.isResumableForAttempt(podWithAttempt("Succeeded", "0"), "1"), is(false));
+        // Live pods stay resumable across attempts - that is the issue #249 reconnect
+        assertThat(PodCreate.isResumableForAttempt(podWithAttempt("Running", "0"), "1"), is(true));
+        assertThat(PodCreate.isResumableForAttempt(podWithAttempt("Pending", "0"), "1"), is(true));
+    }
+
+    private Pod podWithAttempt(String phase, String attempt) {
+        return new PodBuilder()
+            .withNewMetadata()
+            .withName("selection-test")
+            .addToLabels("kestra.io/taskrun-attempt", attempt)
+            .endMetadata()
+            .withNewStatus()
+            .withPhase(phase)
+            .endStatus()
+            .build();
+    }
 }

--- a/src/test/java/io/kestra/plugin/kubernetes/core/PodCreateTest.java
+++ b/src/test/java/io/kestra/plugin/kubernetes/core/PodCreateTest.java
@@ -586,11 +586,12 @@ class PodCreateTest {
             WorkerTask.builder().task(task).taskRun(taskRun).build()
         );
         String labelSelector = "kestra.io/taskrun-id=" + taskRun.getId();
+        String orphanName = "orphan-" + IdUtils.create().toLowerCase();
 
         try (KubernetesClient client = PodService.client(attempt0Context, null)) {
-            Pod orphan = new PodBuilder()
+            var orphan = new PodBuilder()
                 .withNewMetadata()
-                .withName("orphan-" + IdUtils.create().toLowerCase())
+                .withName(orphanName)
                 .withNamespace("default")
                 .addToLabels("kestra.io/taskrun-id", taskRun.getId())
                 .addToLabels("kestra.io/taskrun-attempt", "0")
@@ -624,7 +625,16 @@ class PodCreateTest {
             WorkerTask.builder().task(task).taskRun(resubmittedTaskRun).build()
         );
 
+        Flux<LogEntry> receive = TestsUtils.receive(workerTaskLogQueue);
         task.run(attempt1Context);
+
+        // The planted attempt-0 pod itself must have been resumed, not replaced by a fresh one
+        List<LogEntry> logs = receive.toStream().toList();
+        assertThat(
+            logs.stream().anyMatch(log -> log.getMessage() != null
+                && log.getMessage().contains("Pod '" + orphanName + "' is resumed")),
+            is(true)
+        );
 
         // No pod may remain for this taskrun: the attempt-0 pod was resumed or cleaned up, never orphaned.
         try (KubernetesClient client = PodService.client(attempt1Context, null)) {

--- a/src/test/java/io/kestra/plugin/kubernetes/core/PodCreateTest.java
+++ b/src/test/java/io/kestra/plugin/kubernetes/core/PodCreateTest.java
@@ -580,8 +580,7 @@ class PodCreateTest {
         Execution execution = TestsUtils.mockExecution(flow, Map.of());
         TaskRun taskRun = TestsUtils.mockTaskRun(execution, task);
 
-        // A worker crash is a process death: no cleanup runs, the attempt-0 pod is left behind,
-        // still running, labeled with the previous attempt count. Plant exactly that orphan.
+        // A worker crash runs no cleanup: plant the still-running attempt-0 pod it leaves behind.
         RunContext attempt0Context = runContextInitializer.forWorker(
             (DefaultRunContext) TestsUtils.mockRunContext(runContextFactory, task, Map.of("command", "sleep")),
             WorkerTask.builder().task(task).taskRun(taskRun).build()
@@ -616,8 +615,7 @@ class PodCreateTest {
             );
         }
 
-        // RESUBMIT: after a worker crash the executor re-dispatches the same taskrun with a higher
-        // attempt count. Same taskrun id, attemptsCount bumped by the recorded failed attempt.
+        // RESUBMIT: same taskrun id, attemptsCount bumped by the recorded failed attempt.
         TaskRun resubmittedTaskRun = taskRun.toBuilder()
             .attempts(List.of(TaskRunAttempt.builder().build()))
             .build();
@@ -628,8 +626,7 @@ class PodCreateTest {
 
         task.run(attempt1Context);
 
-        // The resubmitted run must reconnect to the attempt-0 pod (or clean it up), never leave it
-        // orphaned: after completion with delete=true nothing may remain for this taskrun id.
+        // No pod may remain for this taskrun: the attempt-0 pod was resumed or cleaned up, never orphaned.
         try (KubernetesClient client = PodService.client(attempt1Context, null)) {
             Await.until(
                 () -> client.pods().inNamespace("default").withLabelSelector(labelSelector).list().getItems().isEmpty(),

--- a/src/test/java/io/kestra/plugin/kubernetes/core/PodCreateTest.java
+++ b/src/test/java/io/kestra/plugin/kubernetes/core/PodCreateTest.java
@@ -579,70 +579,145 @@ class PodCreateTest {
         Flow flow = TestsUtils.mockFlow();
         Execution execution = TestsUtils.mockExecution(flow, Map.of());
         TaskRun taskRun = TestsUtils.mockTaskRun(execution, task);
+        RunContext attempt1Context = resubmitContext(task, taskRun);
 
-        // A worker crash runs no cleanup: plant the still-running attempt-0 pod it leaves behind.
-        RunContext attempt0Context = runContextInitializer.forWorker(
-            (DefaultRunContext) TestsUtils.mockRunContext(runContextFactory, task, Map.of("command", "sleep")),
-            WorkerTask.builder().task(task).taskRun(taskRun).build()
-        );
         String labelSelector = "kestra.io/taskrun-id=" + taskRun.getId();
+        String staleName = "stale-" + IdUtils.create().toLowerCase();
         String orphanName = "orphan-" + IdUtils.create().toLowerCase();
 
-        try (KubernetesClient client = PodService.client(attempt0Context, null)) {
-            var orphan = new PodBuilder()
-                .withNewMetadata()
-                .withName(orphanName)
-                .withNamespace("default")
-                .addToLabels("kestra.io/taskrun-id", taskRun.getId())
-                .addToLabels("kestra.io/taskrun-attempt", "0")
-                .endMetadata()
-                .withNewSpec()
-                .addNewContainer()
-                .withName("unittest")
-                .withImage("debian:stable-slim")
-                .withCommand("bash", "-c", "seq 1 10 | while read i; do echo \"Resubmit log line $i\"; sleep 0.5; done")
-                .endContainer()
-                .withRestartPolicy("Never")
-                .endSpec()
-                .build();
-            client.pods().inNamespace("default").resource(orphan).create();
-
-            Await.until(
-                () -> {
-                    Pod current = client.pods().inNamespace("default").withName(orphan.getMetadata().getName()).get();
-                    return current != null && current.getStatus() != null && "Running".equals(current.getStatus().getPhase());
-                },
-                Duration.ofMillis(200), Duration.ofMinutes(1)
-            );
-        }
-
-        // RESUBMIT: same taskrun id, attemptsCount bumped by the recorded failed attempt.
-        TaskRun resubmittedTaskRun = taskRun.toBuilder()
-            .attempts(List.of(TaskRunAttempt.builder().build()))
-            .build();
-        RunContext attempt1Context = runContextInitializer.forWorker(
-            (DefaultRunContext) TestsUtils.mockRunContext(runContextFactory, task, Map.of("command", "sleep")),
-            WorkerTask.builder().task(task).taskRun(resubmittedTaskRun).build()
-        );
-
-        Flux<LogEntry> receive = TestsUtils.receive(workerTaskLogQueue);
-        task.run(attempt1Context);
-
-        // The planted attempt-0 pod itself must have been resumed, not replaced by a fresh one
-        List<LogEntry> logs = receive.toStream().toList();
-        assertThat(
-            logs.stream().anyMatch(log -> log.getMessage() != null
-                && log.getMessage().contains("Pod '" + orphanName + "' is resumed")),
-            is(true)
-        );
-
-        // No pod may remain for this taskrun: the attempt-0 pod was resumed or cleaned up, never orphaned.
         try (KubernetesClient client = PodService.client(attempt1Context, null)) {
+            // A worker crash runs no cleanup: plant what it leaves behind - a stale duplicate
+            // and the still-running attempt-0 pod, created in that order so the orphan is newest.
+            plantPod(client, staleName, taskRun.getId(), "sleep 300");
+            awaitPhase(client, staleName, "Running");
+            Thread.sleep(1500);
+            plantPod(client, orphanName, taskRun.getId(), "seq 1 10 | while read i; do echo \"Resubmit log line $i\"; sleep 0.5; done");
+            awaitPhase(client, orphanName, "Running");
+
+            Flux<LogEntry> receive = TestsUtils.receive(workerTaskLogQueue);
+            task.run(attempt1Context);
+            List<LogEntry> logs = receive.toStream().toList();
+
+            // The newest attempt-0 pod itself was resumed, the older duplicate deleted
+            assertLogContains(logs, "Pod '" + orphanName + "' is resumed");
+            assertLogContains(logs, "Deleting stale pod '" + staleName + "'");
+
             Await.until(
                 () -> client.pods().inNamespace("default").withLabelSelector(labelSelector).list().getItems().isEmpty(),
-                Duration.ofMillis(500), Duration.ofSeconds(15)
+                Duration.ofMillis(500), Duration.ofMinutes(1)
             );
+        } finally {
+            deleteLeftoverPods(attempt1Context, labelSelector);
         }
+    }
+
+    @Test
+    void resubmitReplacesFailedPodWithPinnedName() throws Exception {
+        String pinnedName = "pinned-" + IdUtils.create().toLowerCase();
+        PodCreate task = PodCreate.builder()
+            .id(PodCreate.class.getSimpleName())
+            .type(PodCreate.class.getName())
+            .namespace(Property.ofValue("default"))
+            .waitForLogInterval(Property.ofValue(Duration.ofSeconds(1)))
+            .metadata(Map.of("name", pinnedName))
+            .spec(
+                TestUtils.convert(
+                    ObjectMeta.class,
+                    "containers:",
+                    "- name: unittest",
+                    "  image: debian:stable-slim",
+                    "  command: ",
+                    "    - 'bash' ",
+                    "    - '-c'",
+                    "    - 'echo \"Pinned rerun done\"'",
+                    "restartPolicy: Never"
+                )
+            )
+            .resume(Property.ofValue(true))
+            .build();
+
+        Flow flow = TestsUtils.mockFlow();
+        Execution execution = TestsUtils.mockExecution(flow, Map.of());
+        TaskRun taskRun = TestsUtils.mockTaskRun(execution, task);
+        RunContext attempt1Context = resubmitContext(task, taskRun);
+
+        String labelSelector = "kestra.io/taskrun-id=" + taskRun.getId();
+
+        try (KubernetesClient client = PodService.client(attempt1Context, null)) {
+            // The previous attempt failed and its pod uses the same pinned name the resubmit
+            // will want: cleanup must wait for finalization or the create hits 409 AlreadyExists.
+            plantPod(client, pinnedName, taskRun.getId(), "exit 1");
+            awaitPhase(client, pinnedName, "Failed");
+
+            Flux<LogEntry> receive = TestsUtils.receive(workerTaskLogQueue);
+            task.run(attempt1Context);
+            List<LogEntry> logs = receive.toStream().toList();
+
+            assertLogContains(logs, "Deleting stale pod '" + pinnedName + "'");
+            assertLogContains(logs, "Pinned rerun done");
+
+            Await.until(
+                () -> client.pods().inNamespace("default").withLabelSelector(labelSelector).list().getItems().isEmpty(),
+                Duration.ofMillis(500), Duration.ofMinutes(1)
+            );
+        } finally {
+            deleteLeftoverPods(attempt1Context, labelSelector);
+        }
+    }
+
+    private RunContext resubmitContext(PodCreate task, TaskRun taskRun) {
+        // A RESUBMIT reruns the same taskrun id with the failed attempt recorded, so attemptsCount is higher
+        TaskRun resubmitted = taskRun.toBuilder()
+            .attempts(List.of(TaskRunAttempt.builder().build()))
+            .build();
+        return runContextInitializer.forWorker(
+            (DefaultRunContext) TestsUtils.mockRunContext(runContextFactory, task, Map.of("command", "sleep")),
+            WorkerTask.builder().task(task).taskRun(resubmitted).build()
+        );
+    }
+
+    private void plantPod(KubernetesClient client, String name, String taskrunId, String script) {
+        var pod = new PodBuilder()
+            .withNewMetadata()
+            .withName(name)
+            .withNamespace("default")
+            .addToLabels("kestra.io/taskrun-id", taskrunId)
+            .addToLabels("kestra.io/taskrun-attempt", "0")
+            .endMetadata()
+            .withNewSpec()
+            .addNewContainer()
+            .withName("unittest")
+            .withImage("debian:stable-slim")
+            .withCommand("bash", "-c", script)
+            .endContainer()
+            .withRestartPolicy("Never")
+            .endSpec()
+            .build();
+        client.pods().inNamespace("default").resource(pod).create();
+    }
+
+    private void awaitPhase(KubernetesClient client, String name, String phase) throws Exception {
+        Await.until(
+            () -> {
+                Pod current = client.pods().inNamespace("default").withName(name).get();
+                return current != null && current.getStatus() != null && phase.equals(current.getStatus().getPhase());
+            },
+            Duration.ofMillis(200), Duration.ofMinutes(1)
+        );
+    }
+
+    private void deleteLeftoverPods(RunContext runContext, String labelSelector) throws Exception {
+        try (KubernetesClient client = PodService.client(runContext, null)) {
+            client.pods().inNamespace("default").withLabelSelector(labelSelector).delete();
+        }
+    }
+
+    private static void assertLogContains(List<LogEntry> logs, String needle) {
+        assertThat(
+            "expected a log containing: " + needle,
+            logs.stream().anyMatch(log -> log.getMessage() != null && log.getMessage().contains(needle)),
+            is(true)
+        );
     }
 
     @Test

--- a/src/test/java/io/kestra/plugin/kubernetes/core/PodCreateTest.java
+++ b/src/test/java/io/kestra/plugin/kubernetes/core/PodCreateTest.java
@@ -25,6 +25,7 @@ import io.kestra.core.junit.annotations.KestraTest;
 import io.kestra.core.models.executions.Execution;
 import io.kestra.core.models.executions.LogEntry;
 import io.kestra.core.models.executions.TaskRun;
+import io.kestra.core.models.executions.TaskRunAttempt;
 import io.kestra.core.models.flows.Flow;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.queues.QueueFactoryInterface;
@@ -40,6 +41,8 @@ import io.kestra.plugin.kubernetes.shared.models.SideCar;
 import io.kestra.plugin.kubernetes.shared.services.PodService;
 
 import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.PodBuilder;
 import io.fabric8.kubernetes.api.model.Quantity;
 import io.fabric8.kubernetes.api.model.ResourceRequirements;
 import io.fabric8.kubernetes.client.KubernetesClient;
@@ -548,6 +551,91 @@ class PodCreateTest {
 
         List<LogEntry> logs = receive.toStream().toList();
         assertLogExactlyOnce(logs, "Resume log line 10");
+    }
+
+    @Test
+    void resumeAfterResubmitReconnectsToPreviousAttemptPod() throws Exception {
+        PodCreate task = PodCreate.builder()
+            .id(PodCreate.class.getSimpleName())
+            .type(PodCreate.class.getName())
+            .namespace(Property.ofValue("default"))
+            .waitForLogInterval(Property.ofValue(Duration.ofSeconds(1)))
+            .spec(
+                TestUtils.convert(
+                    ObjectMeta.class,
+                    "containers:",
+                    "- name: unittest",
+                    "  image: debian:stable-slim",
+                    "  command: ",
+                    "    - 'bash' ",
+                    "    - '-c'",
+                    "    - 'seq 1 10 | while read i; do echo \"Resubmit log line $i\"; {{ inputs.command }} 0.5; done'",
+                    "restartPolicy: Never"
+                )
+            )
+            .resume(Property.ofValue(true))
+            .build();
+
+        Flow flow = TestsUtils.mockFlow();
+        Execution execution = TestsUtils.mockExecution(flow, Map.of());
+        TaskRun taskRun = TestsUtils.mockTaskRun(execution, task);
+
+        // A worker crash is a process death: no cleanup runs, the attempt-0 pod is left behind,
+        // still running, labeled with the previous attempt count. Plant exactly that orphan.
+        RunContext attempt0Context = runContextInitializer.forWorker(
+            (DefaultRunContext) TestsUtils.mockRunContext(runContextFactory, task, Map.of("command", "sleep")),
+            WorkerTask.builder().task(task).taskRun(taskRun).build()
+        );
+        String labelSelector = "kestra.io/taskrun-id=" + taskRun.getId();
+
+        try (KubernetesClient client = PodService.client(attempt0Context, null)) {
+            Pod orphan = new PodBuilder()
+                .withNewMetadata()
+                .withName("orphan-" + IdUtils.create().toLowerCase())
+                .withNamespace("default")
+                .addToLabels("kestra.io/taskrun-id", taskRun.getId())
+                .addToLabels("kestra.io/taskrun-attempt", "0")
+                .endMetadata()
+                .withNewSpec()
+                .addNewContainer()
+                .withName("unittest")
+                .withImage("debian:stable-slim")
+                .withCommand("bash", "-c", "seq 1 10 | while read i; do echo \"Resubmit log line $i\"; sleep 0.5; done")
+                .endContainer()
+                .withRestartPolicy("Never")
+                .endSpec()
+                .build();
+            client.pods().inNamespace("default").resource(orphan).create();
+
+            Await.until(
+                () -> {
+                    Pod current = client.pods().inNamespace("default").withName(orphan.getMetadata().getName()).get();
+                    return current != null && current.getStatus() != null && "Running".equals(current.getStatus().getPhase());
+                },
+                Duration.ofMillis(200), Duration.ofMinutes(1)
+            );
+        }
+
+        // RESUBMIT: after a worker crash the executor re-dispatches the same taskrun with a higher
+        // attempt count. Same taskrun id, attemptsCount bumped by the recorded failed attempt.
+        TaskRun resubmittedTaskRun = taskRun.toBuilder()
+            .attempts(List.of(TaskRunAttempt.builder().build()))
+            .build();
+        RunContext attempt1Context = runContextInitializer.forWorker(
+            (DefaultRunContext) TestsUtils.mockRunContext(runContextFactory, task, Map.of("command", "sleep")),
+            WorkerTask.builder().task(task).taskRun(resubmittedTaskRun).build()
+        );
+
+        task.run(attempt1Context);
+
+        // The resubmitted run must reconnect to the attempt-0 pod (or clean it up), never leave it
+        // orphaned: after completion with delete=true nothing may remain for this taskrun id.
+        try (KubernetesClient client = PodService.client(attempt1Context, null)) {
+            Await.until(
+                () -> client.pods().inNamespace("default").withLabelSelector(labelSelector).list().getItems().isEmpty(),
+                Duration.ofMillis(500), Duration.ofSeconds(15)
+            );
+        }
     }
 
     @Test

--- a/src/test/java/io/kestra/plugin/kubernetes/core/PodCreateTest.java
+++ b/src/test/java/io/kestra/plugin/kubernetes/core/PodCreateTest.java
@@ -53,6 +53,7 @@ import reactor.core.publisher.Flux;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
 
 @KestraTest
 @Timeout(value = 15, unit = java.util.concurrent.TimeUnit.MINUTES)
@@ -588,19 +589,19 @@ class PodCreateTest {
         try (KubernetesClient client = PodService.client(attempt1Context, null)) {
             // A worker crash runs no cleanup: plant what it leaves behind - a stale duplicate
             // and the still-running attempt-0 pod, created in that order so the orphan is newest.
-            plantPod(client, staleName, taskRun.getId(), "sleep 300");
+            plantPod(client, staleName, taskRun.getId(), "0", "sleep 300");
             awaitPhase(client, staleName, "Running");
             Thread.sleep(1500);
-            plantPod(client, orphanName, taskRun.getId(), "seq 1 10 | while read i; do echo \"Resubmit log line $i\"; sleep 0.5; done");
+            plantPod(client, orphanName, taskRun.getId(), "0", "seq 1 10 | while read i; do echo \"Resubmit log line $i\"; sleep 0.5; done");
             awaitPhase(client, orphanName, "Running");
 
-            Flux<LogEntry> receive = TestsUtils.receive(workerTaskLogQueue);
+            List<LogEntry> logs = new CopyOnWriteArrayList<>();
+            TestsUtils.receive(workerTaskLogQueue, l -> logs.add(l.getLeft()));
             task.run(attempt1Context);
-            List<LogEntry> logs = receive.toStream().toList();
 
             // The newest attempt-0 pod itself was resumed, the older duplicate deleted
-            assertLogContains(logs, "Pod '" + orphanName + "' is resumed");
-            assertLogContains(logs, "Deleting stale pod '" + staleName + "'");
+            awaitLogContains(logs, "Pod '" + orphanName + "' is resumed");
+            awaitLogContains(logs, "Deleting stale pod '" + staleName + "'");
 
             Await.until(
                 () -> client.pods().inNamespace("default").withLabelSelector(labelSelector).list().getItems().isEmpty(),
@@ -629,7 +630,7 @@ class PodCreateTest {
                     "  command: ",
                     "    - 'bash' ",
                     "    - '-c'",
-                    "    - 'echo \"Pinned rerun done\"'",
+                    "    - 'sleep 2; echo \"Pinned rerun done\"; sleep 2'",
                     "restartPolicy: Never"
                 )
             )
@@ -646,20 +647,120 @@ class PodCreateTest {
         try (KubernetesClient client = PodService.client(attempt1Context, null)) {
             // The previous attempt failed and its pod uses the same pinned name the resubmit
             // will want: cleanup must wait for finalization or the create hits 409 AlreadyExists.
-            plantPod(client, pinnedName, taskRun.getId(), "exit 1");
+            plantPod(client, pinnedName, taskRun.getId(), "0", "exit 1");
             awaitPhase(client, pinnedName, "Failed");
 
-            Flux<LogEntry> receive = TestsUtils.receive(workerTaskLogQueue);
+            List<LogEntry> logs = new CopyOnWriteArrayList<>();
+            TestsUtils.receive(workerTaskLogQueue, l -> logs.add(l.getLeft()));
             task.run(attempt1Context);
-            List<LogEntry> logs = receive.toStream().toList();
 
-            assertLogContains(logs, "Deleting stale pod '" + pinnedName + "'");
-            assertLogContains(logs, "Pinned rerun done");
+            awaitLogContains(logs, "Deleting stale pod '" + pinnedName + "'");
+            awaitLogContains(logs, "Pinned rerun done");
 
             Await.until(
                 () -> client.pods().inNamespace("default").withLabelSelector(labelSelector).list().getItems().isEmpty(),
                 Duration.ofMillis(500), Duration.ofMinutes(1)
             );
+        } finally {
+            deleteLeftoverPods(attempt1Context, labelSelector);
+        }
+    }
+
+    @Test
+    void retryDoesNotResumeSucceededPodFromPreviousAttempt() throws Exception {
+        PodCreate task = PodCreate.builder()
+            .id(PodCreate.class.getSimpleName())
+            .type(PodCreate.class.getName())
+            .namespace(Property.ofValue("default"))
+            .waitForLogInterval(Property.ofValue(Duration.ofSeconds(1)))
+            .spec(
+                TestUtils.convert(
+                    ObjectMeta.class,
+                    "containers:",
+                    "- name: unittest",
+                    "  image: debian:stable-slim",
+                    "  command: ",
+                    "    - 'bash' ",
+                    "    - '-c'",
+                    "    - 'sleep 2; echo \"Retry rerun done\"; sleep 2'",
+                    "restartPolicy: Never"
+                )
+            )
+            .resume(Property.ofValue(true))
+            .build();
+
+        Flow flow = TestsUtils.mockFlow();
+        Execution execution = TestsUtils.mockExecution(flow, Map.of());
+        TaskRun taskRun = TestsUtils.mockTaskRun(execution, task);
+        RunContext attempt1Context = resubmitContext(task, taskRun);
+
+        String labelSelector = "kestra.io/taskrun-id=" + taskRun.getId();
+        String succeededName = "succeeded-" + IdUtils.create().toLowerCase();
+
+        try (KubernetesClient client = PodService.client(attempt1Context, null)) {
+            // A retry bumps the attempt count like a resubmit does, but the previous attempt's
+            // Succeeded pod must not be resumed: the retry has to re-run the workload.
+            plantPod(client, succeededName, taskRun.getId(), "0", "echo done");
+            awaitPhase(client, succeededName, "Succeeded");
+
+            List<LogEntry> logs = new CopyOnWriteArrayList<>();
+            TestsUtils.receive(workerTaskLogQueue, l -> logs.add(l.getLeft()));
+            task.run(attempt1Context);
+
+            awaitLogContains(logs, "Retry rerun done");
+            assertThat(
+                logs.stream().anyMatch(log -> log.getMessage() != null
+                    && log.getMessage().contains("Pod '" + succeededName + "' is resumed")),
+                is(false)
+            );
+        } finally {
+            deleteLeftoverPods(attempt1Context, labelSelector);
+        }
+    }
+
+    @Test
+    void resumingSucceededPodWithInputFilesSkipsUploadAndCompletes() throws Exception {
+        PodCreate task = PodCreate.builder()
+            .id(PodCreate.class.getSimpleName())
+            .type(PodCreate.class.getName())
+            .namespace(Property.ofValue("default"))
+            .waitForLogInterval(Property.ofValue(Duration.ofSeconds(1)))
+            .inputFiles(Map.of("data.txt", "content"))
+            .spec(
+                TestUtils.convert(
+                    ObjectMeta.class,
+                    "containers:",
+                    "- name: unittest",
+                    "  image: debian:stable-slim",
+                    "  command: ",
+                    "    - 'bash' ",
+                    "    - '-c'",
+                    "    - 'echo unused'",
+                    "restartPolicy: Never"
+                )
+            )
+            .resume(Property.ofValue(true))
+            .build();
+
+        Flow flow = TestsUtils.mockFlow();
+        Execution execution = TestsUtils.mockExecution(flow, Map.of());
+        TaskRun taskRun = TestsUtils.mockTaskRun(execution, task);
+        RunContext attempt1Context = resubmitContext(task, taskRun);
+
+        String labelSelector = "kestra.io/taskrun-id=" + taskRun.getId();
+        String succeededName = "completed-" + IdUtils.create().toLowerCase();
+
+        try (KubernetesClient client = PodService.client(attempt1Context, null)) {
+            // Same attempt, so the Succeeded pod is resumed. The init-container wait and input
+            // file upload must be skipped for it, or the run blocks for the full waitUntilRunning.
+            plantPod(client, succeededName, taskRun.getId(), "1", "echo \"Completed while worker was down\"");
+            awaitPhase(client, succeededName, "Succeeded");
+
+            List<LogEntry> logs = new CopyOnWriteArrayList<>();
+            TestsUtils.receive(workerTaskLogQueue, l -> logs.add(l.getLeft()));
+            assertTimeoutPreemptively(Duration.ofMinutes(2), () -> task.run(attempt1Context));
+
+            awaitLogContains(logs, "Pod '" + succeededName + "' is resumed");
         } finally {
             deleteLeftoverPods(attempt1Context, labelSelector);
         }
@@ -676,13 +777,13 @@ class PodCreateTest {
         );
     }
 
-    private void plantPod(KubernetesClient client, String name, String taskrunId, String script) {
+    private void plantPod(KubernetesClient client, String name, String taskrunId, String attempt, String script) {
         var pod = new PodBuilder()
             .withNewMetadata()
             .withName(name)
             .withNamespace("default")
             .addToLabels("kestra.io/taskrun-id", taskrunId)
-            .addToLabels("kestra.io/taskrun-attempt", "0")
+            .addToLabels("kestra.io/taskrun-attempt", attempt)
             .endMetadata()
             .withNewSpec()
             .addNewContainer()
@@ -712,11 +813,14 @@ class PodCreateTest {
         }
     }
 
-    private static void assertLogContains(List<LogEntry> logs, String needle) {
-        assertThat(
-            "expected a log containing: " + needle,
-            logs.stream().anyMatch(log -> log.getMessage() != null && log.getMessage().contains(needle)),
-            is(true)
+    /**
+     * Log queue delivery is asynchronous, so expected entries are awaited, never just collected.
+     */
+    private static void awaitLogContains(List<LogEntry> logs, String needle) {
+        TestsUtils.awaitLogs(
+            logs,
+            log -> log.getMessage() != null && log.getMessage().contains(needle),
+            1
         );
     }
 


### PR DESCRIPTION
closes #249

Accepted trade-off: pods are matched by taskrun id across attempts, so after a false-positive worker death the resubmitted attempt takes over (resumes or deletes) pods of a still-live worker. Succeeded pods are only resumed within the same attempt, keeping task retries a real re-run.