### PR TITLE
fix(runner): count files, not lines, when verifying uploads

### DIFF
--- a/src/main/java/io/kestra/plugin/kubernetes/AbstractPod.java
+++ b/src/main/java/io/kestra/plugin/kubernetes/AbstractPod.java
@@ -6,7 +6,6 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.LinkOption;
 import java.nio.file.Path;
-import java.nio.file.StandardCopyOption;
 import java.time.Duration;
 import java.util.*;
 import java.util.stream.Collectors;
@@ -18,7 +17,6 @@ import io.kestra.core.exceptions.IllegalVariableEvaluationException;
 import io.kestra.core.models.annotations.PluginProperty;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.runners.RunContext;
-import io.kestra.core.serializers.JacksonMapper;
 import io.kestra.plugin.kubernetes.shared.models.SideCar;
 import io.kestra.plugin.kubernetes.shared.services.InstanceService;
 import io.kestra.plugin.kubernetes.shared.services.PodService;
@@ -179,7 +177,7 @@ public abstract class AbstractPod extends AbstractConnection {
                             .upload(topAbsolute)
                     );
                     // A genuine truncation won't self-heal across retries — every attempt re-runs the same
-                    // 'find | wc -l' to the same wrong count, burning the full backoff before falling back.
+                    // count check to the same wrong number, burning the full backoff before falling back.
                     // Retrying here anyway is intentional: it's the only thing that catches the transient
                     // race where 'find' runs just before the tar extraction is fully visible on the pod.
                     // Accepted tradeoff — correctness for the race case over shaving a few seconds off a
@@ -224,10 +222,9 @@ public abstract class AbstractPod extends AbstractConnection {
      * fabric8's directory upload can report success even when the tar transfer was truncated (e.g. a
      * dependency directory silently missing files), so cross-check the actual file count on the pod.
      *
-     * Both sides count non-directory entries without following symlinks: tar preserves a symlink as its
-     * own entry (type 'l') rather than dereferencing it, so counting only regular files locally (which
-     * follows symlinks by default) would overcount against the pod-side 'find -type f' and falsely flag
-     * a correct upload as truncated whenever the directory contains symlinks (e.g. a Python venv).
+     * Both sides count non-directory entries. The pod side separates them with NUL rather than newline:
+     * a filename may legally contain a newline, and 'wc -l' would then count one entry several times and
+     * falsely flag a correct upload as truncated.
      *
      * This is a count-only check: a truncation that drops bytes from a file's content while keeping its
      * entry (correct count, short file) is not caught here — only the single-file path ({@link
@@ -241,7 +238,7 @@ public abstract class AbstractPod extends AbstractConnection {
 
         verifyUpload(
             container, logger, containerPath, expectedFileCount, "file(s)",
-            "find " + shellQuote(containerPath) + " \\( -type f -o -type l \\) | wc -l"
+            "find " + shellQuote(containerPath) + " ! -type d -print0 | tr -dc '\\0' | wc -c"
         );
     }
 
@@ -273,7 +270,8 @@ public abstract class AbstractPod extends AbstractConnection {
             return;
         }
 
-        if (!actual.get().equals(expected)) {
+        // Only a shortfall means truncation — a transfer cannot add entries.
+        if (actual.get() < expected) {
             throw new IOException(
                 "Upload verification failed for '" + containerPath + "': expected " + expected + " " + unit + " but found " +
                     actual.get() + " in the file-sidecar container — the tar transfer was likely truncated"
@@ -289,7 +287,8 @@ public abstract class AbstractPod extends AbstractConnection {
         }
     }
 
-    protected Map<Path, Path> downloadOutputFiles(RunContext runContext, PodResource podResource, Logger logger, Map<String, Object> additionalVars, Duration retryMaxDuration) throws Exception {
+    protected Map<Path, Path> downloadOutputFiles(RunContext runContext, PodResource podResource, Logger logger, Map<String, Object> additionalVars, Duration retryMaxDuration)
+        throws Exception {
         withRetries(
             logger,
             "downloadOutputFiles",

--- a/src/test/java/io/kestra/plugin/kubernetes/AbstractPodTest.java
+++ b/src/test/java/io/kestra/plugin/kubernetes/AbstractPodTest.java
@@ -9,6 +9,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
@@ -27,6 +28,10 @@ import io.fabric8.kubernetes.client.dsl.PodResource;
 import io.fabric8.kubernetes.client.dsl.TtyExecErrorable;
 import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
 import jakarta.inject.Inject;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
 
 @MicronautTest
 class AbstractPodTest {
@@ -235,5 +240,77 @@ class AbstractPodTest {
 
         // ...counts matched, so no per-file fallback upload was needed.
         Mockito.verify(container, Mockito.never()).file(Mockito.anyString());
+    }
+
+    @Timeout(value = 15, unit = TimeUnit.MINUTES)
+    @Test
+    void shouldAcceptBulkUploadWhenPodReportsMoreEntriesThanExpected() throws Exception {
+        // Regression test: a filename containing a newline used to make the pod-side 'find | wc -l' count
+        // one file several times, so the check reported a truncated transfer on a perfectly good upload.
+        PodResource podResource = Mockito.mock(PodResource.class);
+        Logger logger = Mockito.mock(Logger.class);
+        ContainerResource container = Mockito.mock(ContainerResource.class);
+
+        Mockito.when(podResource.inContainer("init-files")).thenReturn(container);
+        Mockito.when(container.withReadyWaitTimeout(Mockito.any(Integer.class))).thenReturn(container);
+
+        CopyOrReadable dirUploader = Mockito.mock(CopyOrReadable.class);
+        Mockito.when(container.dir(Mockito.anyString())).thenReturn(dirUploader);
+        Mockito.when(dirUploader.upload(Mockito.any(Path.class))).thenReturn(true);
+
+        CopyOrReadable fileUploader = Mockito.mock(CopyOrReadable.class);
+        Mockito.when(container.file(Mockito.anyString())).thenReturn(fileUploader);
+        Mockito.when(fileUploader.upload(Mockito.any(InputStream.class))).thenReturn(true);
+
+        AtomicReference<String> directoryCheck = new AtomicReference<>();
+
+        // Two files locally, but the pod reports six — the shape a line-counting check produced.
+        Mockito.when(container.writingOutput(Mockito.any(OutputStream.class))).thenAnswer(writingOutputInvocation ->
+        {
+            OutputStream out = writingOutputInvocation.getArgument(0);
+            TtyExecErrorable errorable = Mockito.mock(TtyExecErrorable.class);
+            Mockito.when(errorable.exec(Mockito.any(String[].class))).thenAnswer(execInvocation ->
+            {
+                Object[] command = execInvocation.getArguments();
+                String shellCommand = (String) command[command.length - 1];
+                if (shellCommand.contains("find")) {
+                    directoryCheck.set(shellCommand);
+                }
+                out.write("6".getBytes(StandardCharsets.UTF_8));
+
+                ExecWatch watch = Mockito.mock(ExecWatch.class);
+                Mockito.when(watch.exitCode()).thenReturn(CompletableFuture.completedFuture(0));
+                return watch;
+            });
+            return errorable;
+        });
+
+        RunContext runContext = runContextFactory.of(Map.of());
+        Path temp = PodService.tempDir(runContext);
+
+        Files.createDirectories(temp.resolve("deps"));
+        Files.writeString(temp.resolve("deps/pkg1.txt"), "AA");
+        Files.writeString(temp.resolve("deps/\n\n--- Changes ---\n\n"), "BBB");
+
+        Set<String> inputFiles = Set.of("deps/pkg1.txt", "deps/\n\n--- Changes ---\n\n");
+
+        TestPod pod = new TestPod();
+
+        try (var staticMock = Mockito.mockStatic(PodService.class, Mockito.CALLS_REAL_METHODS)) {
+            staticMock.when(() -> PodService.tempDir(runContext)).thenReturn(temp);
+            staticMock.when(
+                () -> PodService.uploadMarker(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.anyString(), Mockito.anyString())
+            ).thenAnswer(inv -> null);
+
+            pod.uploadInputFiles(runContext, podResource, logger, inputFiles);
+        }
+
+        // An excess count is not a truncation, so the bulk upload stands and nothing is re-uploaded.
+        Mockito.verify(dirUploader, Mockito.times(1)).upload(temp.resolve("deps"));
+        Mockito.verify(container, Mockito.never()).file(Mockito.anyString());
+
+        // The count itself must be NUL-separated, otherwise a newline in a filename inflates it.
+        assertThat(directoryCheck.get(), containsString("-print0"));
+        assertThat(directoryCheck.get(), not(containsString("wc -l")));
     }
 }


### PR DESCRIPTION
  find | wc -l emits a line per newline, so a filename containing one inflates
  the pod-side count and the check wrongly reports a truncated transfer. Count
  NUL-separated entries instead, and only fail when the pod has fewer files than
  expected — a truncation can't add any.

  Drops -type l: fabric8 dereferences symlinks on upload, so it never matched.