### PR TITLE
fix(test): await async log delivery before asserting exactly-once

### DIFF
--- a/src/main/java/io/kestra/plugin/kubernetes/core/PodCreate.java
+++ b/src/main/java/io/kestra/plugin/kubernetes/core/PodCreate.java
@@ -30,9 +30,9 @@ import io.kestra.core.models.tasks.runners.ScriptService;
 import io.kestra.core.runners.RunContext;
 import io.kestra.core.utils.IdUtils;
 import io.kestra.plugin.kubernetes.AbstractPod;
-import io.kestra.plugin.kubernetes.shared.models.Connection;
 import io.kestra.plugin.kubernetes.models.Metadata;
 import io.kestra.plugin.kubernetes.models.PodStatus;
+import io.kestra.plugin.kubernetes.shared.models.Connection;
 import io.kestra.plugin.kubernetes.shared.services.InstanceService;
 import io.kestra.plugin.kubernetes.shared.services.PodLogService;
 import io.kestra.plugin.kubernetes.shared.services.PodService;
@@ -590,9 +590,11 @@ public class PodCreate extends AbstractPod implements RunnableTask<PodCreate.Out
             Comparator<Pod> byPriority = Comparator.comparingInt(PodCreate::resumePriority);
             var resumed = existingPods.stream()
                 .filter(p -> isResumableForAttempt(p, attempt))
-                .max(byPriority
-                    .thenComparing(p -> p.getMetadata().getCreationTimestamp(), Comparator.nullsFirst(Comparator.naturalOrder()))
-                    .thenComparing(p -> p.getMetadata().getName()))
+                .max(
+                    byPriority
+                        .thenComparing(p -> p.getMetadata().getCreationTimestamp(), Comparator.nullsFirst(Comparator.naturalOrder()))
+                        .thenComparing(p -> p.getMetadata().getName())
+                )
                 .orElse(null);
 
             // Delete stale pods so a previous attempt cannot break quotas or concurrency limits.
@@ -845,7 +847,8 @@ public class PodCreate extends AbstractPod implements RunnableTask<PodCreate.Out
      * throw while fetching logs), so the caller can build the {@link Output} before raising the failure
      * and keep the original exception as the cause.
      */
-    private IllegalStateException handleEnd(Pod ended, RunContext runContext, boolean hasOutputFiles, KubernetesClient client, PodLogService podLogService, AbstractLogConsumer logConsumer) throws Exception {
+    private IllegalStateException handleEnd(Pod ended, RunContext runContext, boolean hasOutputFiles, KubernetesClient client, PodLogService podLogService, AbstractLogConsumer logConsumer)
+        throws Exception {
         Logger logger = runContext.logger();
 
         // Wait for async log stream (watchLog) to finish processing

--- a/src/main/java/io/kestra/plugin/kubernetes/kubectl/Apply.java
+++ b/src/main/java/io/kestra/plugin/kubernetes/kubectl/Apply.java
@@ -14,8 +14,8 @@ import io.kestra.core.models.tasks.RunnableTask;
 import io.kestra.core.runners.RunContext;
 import io.kestra.plugin.kubernetes.AbstractPod;
 import io.kestra.plugin.kubernetes.models.Metadata;
-import io.kestra.plugin.kubernetes.shared.services.PodService;
 import io.kestra.plugin.kubernetes.services.ResourceWaitService;
+import io.kestra.plugin.kubernetes.shared.services.PodService;
 
 import io.fabric8.kubernetes.api.model.GenericKubernetesResource;
 import io.fabric8.kubernetes.api.model.HasMetadata;

--- a/src/main/java/io/kestra/plugin/kubernetes/kubectl/Get.java
+++ b/src/main/java/io/kestra/plugin/kubernetes/kubectl/Get.java
@@ -25,8 +25,8 @@ import io.kestra.core.serializers.FileSerde;
 import io.kestra.plugin.kubernetes.AbstractPod;
 import io.kestra.plugin.kubernetes.models.Metadata;
 import io.kestra.plugin.kubernetes.models.ResourceStatus;
-import io.kestra.plugin.kubernetes.shared.services.PodService;
 import io.kestra.plugin.kubernetes.services.ResourceWaitService;
+import io.kestra.plugin.kubernetes.shared.services.PodService;
 
 import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.dsl.base.ResourceDefinitionContext;

--- a/src/main/java/io/kestra/plugin/kubernetes/kubectl/Patch.java
+++ b/src/main/java/io/kestra/plugin/kubernetes/kubectl/Patch.java
@@ -12,8 +12,8 @@ import io.kestra.plugin.kubernetes.AbstractPod;
 import io.kestra.plugin.kubernetes.models.Metadata;
 import io.kestra.plugin.kubernetes.models.PatchStrategy;
 import io.kestra.plugin.kubernetes.models.ResourceStatus;
-import io.kestra.plugin.kubernetes.shared.services.PodService;
 import io.kestra.plugin.kubernetes.services.ResourceWaitService;
+import io.kestra.plugin.kubernetes.shared.services.PodService;
 
 import io.fabric8.kubernetes.client.dsl.base.PatchContext;
 import io.fabric8.kubernetes.client.dsl.base.PatchType;

--- a/src/main/java/io/kestra/plugin/kubernetes/models/Metadata.java
+++ b/src/main/java/io/kestra/plugin/kubernetes/models/Metadata.java
@@ -4,13 +4,14 @@ import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 
+import io.kestra.core.models.annotations.PluginProperty;
+
 import io.fabric8.kubernetes.api.model.ManagedFieldsEntry;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.api.model.OwnerReference;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
-import io.kestra.core.models.annotations.PluginProperty;
 
 @Builder
 @Getter

--- a/src/main/java/io/kestra/plugin/kubernetes/models/ResourceStatus.java
+++ b/src/main/java/io/kestra/plugin/kubernetes/models/ResourceStatus.java
@@ -2,11 +2,12 @@ package io.kestra.plugin.kubernetes.models;
 
 import java.util.Map;
 
+import io.kestra.core.models.annotations.PluginProperty;
+
 import io.fabric8.kubernetes.api.model.GenericKubernetesResource;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
-import io.kestra.core.models.annotations.PluginProperty;
 
 @Builder
 @Getter

--- a/src/test/java/io/kestra/plugin/kubernetes/core/PodCreateTest.java
+++ b/src/test/java/io/kestra/plugin/kubernetes/core/PodCreateTest.java
@@ -105,7 +105,8 @@ class PodCreateTest {
 
     @Test
     void run() throws Exception {
-        Flux<LogEntry> receive = TestsUtils.receive(workerTaskLogQueue);
+        List<LogEntry> logs = new CopyOnWriteArrayList<>();
+        TestsUtils.receive(workerTaskLogQueue, l -> logs.add(l.getLeft()));
 
         PodCreate task = PodCreate.builder()
             .id(PodCreate.class.getSimpleName())
@@ -138,7 +139,13 @@ class PodCreateTest {
 
         assertThat(runOutput.getMetadata().getName(), containsString("podcreate"));
 
-        List<LogEntry> logs = receive.collectList().block();
+        // The log queue delivers asynchronously, so wait for all expected entries to land before asserting exactly-once
+        Await.until(
+            () -> logs.stream().filter(l -> l.getMessage() != null && l.getMessage().startsWith("Log line ")).count() >= 20
+                && logs.stream().anyMatch(l -> "error".equals(l.getMessage())),
+            Duration.ofMillis(100),
+            Duration.ofSeconds(30)
+        );
 
         // Verify all 20 log lines are present exactly once (no duplicates, no missing)
         for (int i = 1; i <= 20; i++) {
@@ -503,7 +510,8 @@ class PodCreateTest {
 
     @Test
     void resume() throws Exception {
-        Flux<LogEntry> receive = TestsUtils.receive(workerTaskLogQueue);
+        List<LogEntry> logs = new CopyOnWriteArrayList<>();
+        TestsUtils.receive(workerTaskLogQueue, l -> logs.add(l.getLeft()));
 
         PodCreate task = PodCreate.builder()
             .id(PodCreate.class.getSimpleName())
@@ -559,7 +567,13 @@ class PodCreateTest {
 
         task.run(finalRunContext);
 
-        List<LogEntry> logs = receive.toStream().toList();
+        // The log queue delivers asynchronously, so wait for all expected entries to land before asserting exactly-once
+        Await.until(
+            () -> logs.stream().anyMatch(l -> "Resume log line 10".equals(l.getMessage())),
+            Duration.ofMillis(100),
+            Duration.ofSeconds(30)
+        );
+
         assertLogExactlyOnce(logs, "Resume log line 10");
     }
 
@@ -1280,7 +1294,8 @@ class PodCreateTest {
 
     @Test
     void multipleContainersOneFailsWithOutputFiles() throws Exception {
-        Flux<LogEntry> receive = TestsUtils.receive(workerTaskLogQueue);
+        List<LogEntry> logs = new CopyOnWriteArrayList<>();
+        TestsUtils.receive(workerTaskLogQueue, l -> logs.add(l.getLeft()));
 
         PodCreate task = PodCreate.builder()
             .id(PodCreate.class.getSimpleName())
@@ -1319,7 +1334,13 @@ class PodCreateTest {
         assertThat(exception.getMessage(), containsString("exit code 1"));
         assertThat(exception.getOutput(), notNullValue());
 
-        List<LogEntry> logs = receive.collectList().block();
+        // The log queue delivers asynchronously, so wait for all expected entries to land before asserting exactly-once
+        Await.until(
+            () -> logs.stream().anyMatch(l -> "First container succeeded".equals(l.getMessage()))
+                && logs.stream().anyMatch(l -> "Second container failing".equals(l.getMessage())),
+            Duration.ofMillis(100),
+            Duration.ofSeconds(30)
+        );
 
         // Verify logs from both containers were collected exactly once (no duplicates)
         assertLogExactlyOnce(logs, "First container succeeded");

--- a/src/test/java/io/kestra/plugin/kubernetes/core/PodCreateTest.java
+++ b/src/test/java/io/kestra/plugin/kubernetes/core/PodCreateTest.java
@@ -732,8 +732,10 @@ class PodCreateTest {
 
             awaitLogContains(logs, "Retry rerun done");
             assertThat(
-                logs.stream().anyMatch(log -> log.getMessage() != null
-                    && log.getMessage().contains("Pod '" + succeededName + "' is resumed")),
+                logs.stream().anyMatch(
+                    log -> log.getMessage() != null
+                        && log.getMessage().contains("Pod '" + succeededName + "' is resumed")
+                ),
                 is(false)
             );
         } finally {
@@ -822,7 +824,8 @@ class PodCreateTest {
 
     private void awaitPhase(KubernetesClient client, String name, String phase) throws Exception {
         Await.until(
-            () -> {
+            () ->
+            {
                 Pod current = client.pods().inNamespace("default").withName(name).get();
                 return current != null && current.getStatus() != null && phase.equals(current.getStatus().getPhase());
             },


### PR DESCRIPTION
## Why

`PodCreateTest.run()` failed on the nightly [run 33590236587](https://github.com/kestra-io/plugin-kubernetes/actions/runs/33590236587/job/100122565633) with:

```
java.lang.AssertionError: Missing or duplicate log: Log line 17 from test pod
Expected: is <1L>
     but: was <0L>
```

**This is a test race, not a plugin regression.** The task emitted all 21 lines exactly once — the logback console output for that test shows `Log line 1` … `Log line 20` plus `error`, each once, and the final-log fetch (`Fetching final logs since lookbackTime=…`) re-emitted nothing. The line was lost between `runContext.logger()` and the assertion list.

`TestsUtils.receive(queue)` (kestra `tests` 1.3.13) registers an async queue consumer that appends every `LogEntry` into an internal `CopyOnWriteArrayList`, then returns:

```java
Flux.create(sink -> { list.forEach(sink::next); sink.complete(); })
```

That flux emits **a snapshot of whatever has arrived at subscribe time and completes immediately — it never waits**. So `receive.collectList().block()` / `receive.toStream().toList()`, called right after `task.run(...)` returns, can miss entries still in flight on the queue dispatch threads.

The collected list proves the delivery is unordered and laggy: it held `…16, 18, 20, error, 19` — line 19 landed after line 20 and after `error`. Line 17 simply had not been appended yet when the snapshot was taken (`Pod '…' is deleted` was missing for the same reason).

The same failure mode already hit `Resume log line 10` on [run 31860330200](https://github.com/kestra-io/plugin-kubernetes/actions/runs/31860330200) (2026-08-15), so this is a recurring flake — roughly 2 hits in the last 25 runs of `main`.

## What

Three tests still used the racy snapshot; they now collect into their own list via the consumer overload and await the expected entries before asserting — the pattern `completeLogCollectionAfterQuickTermination()` already uses in this file:

| Test | Awaits |
| --- | --- |
| `run()` | ≥ 20 messages starting with `Log line ` **and** one equal to `error` (last line the pod writes) |
| `resume()` | `Resume log line 10` (last line the pod writes) |
| `multipleContainersOneFailsWithOutputFiles()` | both `First container succeeded` and `Second container failing` |

Poll interval 100 ms, timeout 30 s.

The awaits deliberately use `>=`/presence checks rather than exact counts: a duplicate then still fails through the existing `assertLogExactlyOnce` with its clear `Missing or duplicate log: …` message, instead of surfacing as an opaque await timeout. **No `assertLogExactlyOnce` assertion is removed or weakened**, so the duplicate-detection guard added in #320 stays intact.

`resume()`'s separate `shutdownReceive` consumer is untouched.

## Second commit: `chore: apply spotless`

`./gradlew spotlessCheck` had been failing on `main` since the `spotless-conventions` bump in aad0948 — import ordering in six files under `src/main` plus two lambda-wrapping spots in `PodCreateTest`. Fixed here in a separate commit so the test fix stays reviewable on its own. Formatting only, no behavior change.

## Testing

- `./gradlew compileJava compileTestJava spotlessCheck --rerun-tasks` passes.
- The three tests require a live Kubernetes cluster + GCP credentials, so they only run in CI — CI on this PR is the real verification.

