### PR TITLE
fix(kubernetes): skip pod-Ready wait on init-files input file upload

### DIFF
--- a/src/main/java/io/kestra/plugin/kubernetes/AbstractPod.java
+++ b/src/main/java/io/kestra/plugin/kubernetes/AbstractPod.java
@@ -157,9 +157,16 @@ public abstract class AbstractPod extends AbstractConnection {
                 return p.getNameCount() > 0 ? p.getName(0).toString() : file;
             }));
 
+        // Every fabric8 exec/upload call re-waits for the whole pod to report Ready before opening the
+        // connection — see PodOperationsImpl#getURL. That wait is structurally doomed to run to its full
+        // timeout here: the pod can't be Ready while init-files is itself still blocked waiting for the
+        // ready marker file, which is exactly the upload this call is about to perform. The caller already
+        // proved this container is Running via PodService.waitForInitContainerRunning() right before this
+        // call, so skip the redundant, unsatisfiable pod-Ready wait entirely instead of paying it on every
+        // retry attempt.
         ContainerResource container = podResource
             .inContainer(INIT_FILES_CONTAINER_NAME)
-            .withReadyWaitTimeout(PodService.EXEC_READY_WAIT_TIMEOUT_MS);
+            .withReadyWaitTimeout(0);
 
         for (Map.Entry<String, List<String>> entry : grouped.entrySet()) {
 

--- a/src/main/java/io/kestra/plugin/kubernetes/AbstractPod.java
+++ b/src/main/java/io/kestra/plugin/kubernetes/AbstractPod.java
@@ -164,6 +164,14 @@ public abstract class AbstractPod extends AbstractConnection {
         // proved this container is Running via PodService.waitForInitContainerRunning() right before this
         // call, so skip the redundant, unsatisfiable pod-Ready wait entirely instead of paying it on every
         // retry attempt.
+        //
+        // Do NOT restore a positive timeout here. This value has already round-tripped once: it was set to
+        // 30s (bf45e73) to stop intermittent "exec endpoint not initialized yet" failures seen even while
+        // the pod was Running. That concern is real, but a pod-Ready wait cannot address it at THIS call
+        // site — the condition it waits on is unsatisfiable until after this very upload, so any positive
+        // value is dead time that expires and proceeds anyway, never protection. Transient exec-endpoint
+        // failures are covered instead by PodService.withRetries (5 attempts, 1s→10s backoff, 60s budget),
+        // which only became effective once each attempt stopped burning the full timeout first.
         ContainerResource container = podResource
             .inContainer(INIT_FILES_CONTAINER_NAME)
             .withReadyWaitTimeout(0);

--- a/src/test/java/io/kestra/plugin/kubernetes/AbstractPodTest.java
+++ b/src/test/java/io/kestra/plugin/kubernetes/AbstractPodTest.java
@@ -55,7 +55,7 @@ class AbstractPodTest {
         Mockito.when(podResource.inContainer("init-files"))
             .thenReturn(container);
 
-        Mockito.when(container.withReadyWaitTimeout(PodService.EXEC_READY_WAIT_TIMEOUT_MS))
+        Mockito.when(container.withReadyWaitTimeout(0))
             .thenReturn(container);
 
         Mockito.when(container.file(Mockito.anyString()))
@@ -89,6 +89,10 @@ class AbstractPodTest {
 
             pod.uploadInputFiles(runContext, podResource, logger, inputFiles);
         }
+
+        // Pins the fix for #329: init-files uploads must skip the pod-Ready wait, since the pod
+        // structurally cannot become Ready while init-files itself is blocked on the ready marker.
+        Mockito.verify(container).withReadyWaitTimeout(0);
 
         Mockito.verify(container, Mockito.times(1)).file("/kestra/working-dir/a.txt");
         Mockito.verify(container, Mockito.times(1)).file("/kestra/working-dir/b.txt");

--- a/src/test/java/io/kestra/plugin/kubernetes/AbstractPodTest.java
+++ b/src/test/java/io/kestra/plugin/kubernetes/AbstractPodTest.java
@@ -111,8 +111,9 @@ class AbstractPodTest {
         ContainerResource container = Mockito.mock(ContainerResource.class);
 
         Mockito.when(podResource.inContainer("init-files")).thenReturn(container);
-        // Both the raw upload (30s) and the verification-only exec (0s, see PodService#execOutput) reuse
-        // this same container mock, so both readyWaitTimeout values must resolve back to it.
+        // Both the raw upload and the verification-only exec (see PodService#execOutput) now pass a 0
+        // readyWaitTimeout and reuse this same container mock, so keep the lenient matcher here: the
+        // exact value is pinned by shouldUploadInputFiles instead.
         Mockito.when(container.withReadyWaitTimeout(Mockito.any(Integer.class))).thenReturn(container);
 
         CopyOrReadable dirUploader = Mockito.mock(CopyOrReadable.class);
@@ -189,8 +190,9 @@ class AbstractPodTest {
         ContainerResource container = Mockito.mock(ContainerResource.class);
 
         Mockito.when(podResource.inContainer("init-files")).thenReturn(container);
-        // Both the raw upload (30s) and the verification-only exec (0s, see PodService#execOutput) reuse
-        // this same container mock, so both readyWaitTimeout values must resolve back to it.
+        // Both the raw upload and the verification-only exec (see PodService#execOutput) now pass a 0
+        // readyWaitTimeout and reuse this same container mock, so keep the lenient matcher here: the
+        // exact value is pinned by shouldUploadInputFiles instead.
         Mockito.when(container.withReadyWaitTimeout(Mockito.any(Integer.class))).thenReturn(container);
 
         CopyOrReadable dirUploader = Mockito.mock(CopyOrReadable.class);


### PR DESCRIPTION
## Summary

- `AbstractPod.uploadInputFiles()` set `withReadyWaitTimeout(PodService.EXEC_READY_WAIT_TIMEOUT_MS)` (30s) on the `init-files` container before uploading input files. Every fabric8 upload/exec call re-waits for the *whole pod* to report Ready before opening the exec connection, but the pod structurally cannot become Ready while `init-files` is itself blocked waiting for `/kestra/ready` — which Kestra only writes *after* the upload completes. Every upload to that container therefore paid the full readiness timeout before proceeding, which is where the reported ~150s went. (The issue's `5 x 30s = 150s` arithmetic is a plausible fit but was **not** confirmed: in fabric8 7.8.0 the readiness wait is best-effort — `PodOperationUtil.waitUntilReadyOrTerminal` logs and proceeds on timeout rather than failing — so the stall is one doomed wait per upload/exec call, not five failed retries. The exact decomposition of the original 174s was not pinned down; what is established is that the wait was unsatisfiable by construction and is now gone.)
- Changed the timeout to `0` (no wait), matching the pattern already used by `PodService.uploadMarker()`, `PodService.execOutput()` (in `plugin-kubernetes-lib`), and `plugin-ee-kubernetes`'s `Kubernetes#uploadInputFiles()`. Safe because `PodCreate` calls `PodService.waitForInitContainerRunning()` immediately before the upload, proving the target container is already Running.
- Added a comment at the call site explaining why `0` is correct, mirroring the wording used in `PodService.execOutput()`'s javadoc.
- Updated `AbstractPodTest#shouldUploadInputFiles` to stub and `verify` the explicit `0` timeout (was `PodService.EXEC_READY_WAIT_TIMEOUT_MS`), pinning the regression instead of asserting it loosely.

## Measurements (local `kind` cluster, `PodCreateTest.inputOutputFiles`)

- **Before**: 2m 54s / 2m 46s test-method time across two runs (~150s dominated by the doomed pod-Ready wait retried 5x). Confirmed the mechanism directly: `kubectl exec -c init-files <pod> -- ls -lah /kestra/working-dir` showed the input file already present in the container while `/kestra/ready` was still absent and the pod's `Ready`/`Initialized` conditions stayed `False` — the upload only completed once the doomed readiness wait had elapsed, while the file itself was visible in the container almost immediately.
- **After**: 12.4s test-method time. The stall is gone.

## Intentional behavior change

Genuinely failing uploads (e.g. real connectivity issues) now surface errors in seconds instead of up to 150s, since each retry attempt no longer burns a doomed 30s wait before failing. Same exception type and hint message — only the latency to observe a real failure changes, this is the desired outcome of the fix.

## Out of scope (unchanged)

- `UPLOAD_RETRY_MAX_ATTEMPTS` / `DEFAULT_RETRY_MAX_DURATION` retry policy — untouched.
- `plugin-kubernetes-lib` and `plugin-ee-kubernetes` — both already correct, no changes made.
- Output-file download path (`downloadOutputFiles`) — unaffected.

closes: https://github.com/kestra-io/plugin-kubernetes/issues/329

## Test plan

- [x] `rtk test ./gradlew test` passes (full suite)
- [x] `rtk test ./gradlew test --tests '*AbstractPodTest*'` passes
- [x] `rtk test ./gradlew test --tests '*core.PodCreateTest*'` passes
- [x] Reproduced the ~150s stall against a local `kind` cluster before the fix, and confirmed it is gone after (12.4s)

---
*[View as Artifact](https://claude.ai/code/artifact/16145200-36ea-4e03-9dd9-f040ef2b73d1)*
