### PR TITLE
fix(kubernetes): tolerate marker upload exec failure after init-files exit 0

### DIFF
--- a/src/main/java/io/kestra/plugin/kubernetes/AbstractPod.java
+++ b/src/main/java/io/kestra/plugin/kubernetes/AbstractPod.java
@@ -241,7 +241,14 @@ public abstract class AbstractPod extends AbstractConnection {
         } catch (IOException e) {
             // The init container exits only when it finds /kestra/ready, so exit code 0 means
             // the marker arrived even if the exec WebSocket closed before fabric8 got a clean result.
-            Pod current = podResource.get();
+            Pod current;
+            try {
+                current = podResource.get();
+            } catch (RuntimeException lookupError) {
+                // Status lookup failed too — surface the original upload error, not this one.
+                e.addSuppressed(lookupError);
+                throw e;
+            }
             boolean initContainerSucceeded = current != null &&
                 current.getStatus() != null &&
                 current.getStatus().getInitContainerStatuses() != null &&

--- a/src/main/java/io/kestra/plugin/kubernetes/AbstractPod.java
+++ b/src/main/java/io/kestra/plugin/kubernetes/AbstractPod.java
@@ -205,6 +205,12 @@ public abstract class AbstractPod extends AbstractConnection {
                 }
             }
 
+            // OSS keys always resolve to regular files here: PodCreate passes
+            // validatedInputFiles.keySet(), and PluginUtilsService.createInputFilesInternal materialises
+            // every key through a FileOutputStream (creating only parent dirs). Only the grouped top-level
+            // name can be a directory, which the bulk branch above already handles. EE differs because it
+            // walks the working dir into a List<Path> that can contain directory entries — do not "fix"
+            // this to match EE.
             for (String file : entry.getValue()) {
                 String target = "/kestra/working-dir/" + file;
                 withRetries(
@@ -230,7 +236,28 @@ public abstract class AbstractPod extends AbstractConnection {
             }
         }
 
-        PodService.uploadMarker(runContext, podResource, logger, READY_MARKER, INIT_FILES_CONTAINER_NAME);
+        try {
+            PodService.uploadMarker(runContext, podResource, logger, READY_MARKER, INIT_FILES_CONTAINER_NAME);
+        } catch (IOException e) {
+            // The init container exits only when it finds /kestra/ready, so exit code 0 means
+            // the marker arrived even if the exec WebSocket closed before fabric8 got a clean result.
+            Pod current = podResource.get();
+            boolean initContainerSucceeded = current != null &&
+                current.getStatus() != null &&
+                current.getStatus().getInitContainerStatuses() != null &&
+                current.getStatus().getInitContainerStatuses().stream()
+                    .filter(cs -> INIT_FILES_CONTAINER_NAME.equals(cs.getName()))
+                    .anyMatch(
+                        cs -> cs.getState() != null &&
+                            cs.getState().getTerminated() != null &&
+                            Integer.valueOf(0).equals(cs.getState().getTerminated().getExitCode())
+                    );
+            if (initContainerSucceeded) {
+                logger.debug("uploadMarker exec failed but init container exited with code 0, marker was received");
+            } else {
+                throw e;
+            }
+        }
     }
 
     /**

--- a/src/test/java/io/kestra/plugin/kubernetes/AbstractPodTest.java
+++ b/src/test/java/io/kestra/plugin/kubernetes/AbstractPodTest.java
@@ -1,5 +1,6 @@
 package io.kestra.plugin.kubernetes;
 
+import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
@@ -21,6 +22,12 @@ import io.kestra.core.runners.RunContext;
 import io.kestra.core.runners.RunContextFactory;
 import io.kestra.plugin.kubernetes.shared.services.PodService;
 
+import io.fabric8.kubernetes.api.model.ContainerStateBuilder;
+import io.fabric8.kubernetes.api.model.ContainerStateTerminatedBuilder;
+import io.fabric8.kubernetes.api.model.ContainerStatus;
+import io.fabric8.kubernetes.api.model.ContainerStatusBuilder;
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.PodBuilder;
 import io.fabric8.kubernetes.client.dsl.ContainerResource;
 import io.fabric8.kubernetes.client.dsl.CopyOrReadable;
 import io.fabric8.kubernetes.client.dsl.ExecWatch;
@@ -32,6 +39,8 @@ import jakarta.inject.Inject;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.not;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @MicronautTest
 class AbstractPodTest {
@@ -98,6 +107,79 @@ class AbstractPodTest {
         Mockito.verify(container, Mockito.times(1)).file("/kestra/working-dir/b.txt");
 
         Mockito.verify(fileUploader, Mockito.times(2)).upload(Mockito.any(InputStream.class));
+    }
+
+    @Test
+    void shouldTolerateMarkerUploadFailureWhenInitContainerSucceeded() throws Exception {
+        // Regression test: fabric8's exec WebSocket can close before reporting a clean result even though
+        // the init container already consumed the ready marker and exited. That must be tolerated, not
+        // surfaced as a task failure.
+        PodResource podResource = Mockito.mock(PodResource.class);
+        ContainerResource container = Mockito.mock(ContainerResource.class);
+        Logger logger = Mockito.mock(Logger.class);
+
+        Mockito.when(podResource.inContainer("init-files")).thenReturn(container);
+        Mockito.when(container.withReadyWaitTimeout(0)).thenReturn(container);
+
+        ContainerStatus initFilesStatus = new ContainerStatusBuilder()
+            .withName(AbstractPod.INIT_FILES_CONTAINER_NAME)
+            .withState(new ContainerStateBuilder()
+                .withTerminated(new ContainerStateTerminatedBuilder().withExitCode(0).build())
+                .build())
+            .build();
+        Pod terminatedPod = new PodBuilder()
+            .withNewStatus()
+                .withInitContainerStatuses(initFilesStatus)
+            .endStatus()
+            .build();
+        Mockito.when(podResource.get()).thenReturn(terminatedPod);
+
+        RunContext runContext = runContextFactory.of(Map.of());
+        TestPod pod = new TestPod();
+
+        // inputFiles is empty, so tempDir is computed but never dereferenced — no need to stub it.
+        try (MockedStatic<PodService> staticMock = Mockito.mockStatic(PodService.class)) {
+            staticMock.when(
+                () -> PodService.uploadMarker(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.anyString(), Mockito.anyString())
+            ).thenThrow(new IOException("exec WebSocket closed before result"));
+
+            assertDoesNotThrow(() -> pod.uploadInputFiles(runContext, podResource, logger, Set.of()));
+        }
+    }
+
+    @Test
+    void shouldPropagateMarkerUploadFailureWhenInitContainerDidNotSucceed() throws Exception {
+        PodResource podResource = Mockito.mock(PodResource.class);
+        ContainerResource container = Mockito.mock(ContainerResource.class);
+        Logger logger = Mockito.mock(Logger.class);
+
+        Mockito.when(podResource.inContainer("init-files")).thenReturn(container);
+        Mockito.when(container.withReadyWaitTimeout(0)).thenReturn(container);
+
+        ContainerStatus initFilesStatus = new ContainerStatusBuilder()
+            .withName(AbstractPod.INIT_FILES_CONTAINER_NAME)
+            .withState(new ContainerStateBuilder()
+                .withTerminated(new ContainerStateTerminatedBuilder().withExitCode(1).build())
+                .build())
+            .build();
+        Pod failedPod = new PodBuilder()
+            .withNewStatus()
+                .withInitContainerStatuses(initFilesStatus)
+            .endStatus()
+            .build();
+        Mockito.when(podResource.get()).thenReturn(failedPod);
+
+        RunContext runContext = runContextFactory.of(Map.of());
+        TestPod pod = new TestPod();
+
+        // inputFiles is empty, so tempDir is computed but never dereferenced — no need to stub it.
+        try (MockedStatic<PodService> staticMock = Mockito.mockStatic(PodService.class)) {
+            staticMock.when(
+                () -> PodService.uploadMarker(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.anyString(), Mockito.anyString())
+            ).thenThrow(new IOException("exec WebSocket closed before result"));
+
+            assertThrows(IOException.class, () -> pod.uploadInputFiles(runContext, podResource, logger, Set.of()));
+        }
     }
 
     @Timeout(value = 15, unit = TimeUnit.MINUTES)


### PR DESCRIPTION
## Summary

- `AbstractPod.uploadInputFiles` now wraps `PodService.uploadMarker(...)` in the same guard already present in `plugin-ee-kubernetes`: on `IOException`, it re-fetches the pod and treats a terminated `init-files` init-container with exit code `0` as success (logged at `debug`), rethrowing otherwise. This closes the confirmed gap from issue #335's acceptance criterion 2a — fabric8's exec WebSocket can close before reporting a clean result even though the init container already consumed the ready marker and exited.
- Added `AbstractPodTest#shouldTolerateMarkerUploadFailureWhenInitContainerSucceeded` and its negative twin `shouldPropagateMarkerUploadFailureWhenInitContainerDidNotSucceed`, reusing the existing Mockito harness. The `Mockito.verify(container).withReadyWaitTimeout(0)` pinning assertion from #334 is untouched.
- Documented (per 2b/2c) why OSS's per-file upload loop deliberately does not port EE's `Files.isDirectory` branch: OSS `inputFiles` keys always materialise as regular files via `PluginUtilsService.createInputFilesInternal`, so only the grouped top-level name can be a directory, which the existing bulk branch already handles.

This PR delivers **Follow-up 2 only** from issue #335. Follow-up 1 (consolidating `uploadInputFiles` and its verify helpers into `plugin-kubernetes-lib`, releasing the lib, and bumping it in both this repo and `plugin-ee-kubernetes`) is tracked separately and is deliberately out of scope here.

part-of: https://github.com/kestra-io/plugin-kubernetes/issues/335

## Test plan

- [x] `rtk test ./gradlew test` passes (65 tests, 0 failures, run against a local `kind-kind` cluster)
- [x] `./gradlew shadowJar` builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
*[View as Artifact](https://claude.ai/code/artifact/2a4cc0b8-1764-4755-9f52-fae961ea45d5)*