### PR TITLE
refactor(kubernetes): consume PodService.uploadInputFiles from plugin-kubernetes-lib

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,7 +56,7 @@ dependencies {
 
     // plugins
     // Shared kernel with plugin-ee-kubernetes; brings io.fabric8:kubernetes-client and commons-compress transitively.
-    api 'io.kestra.plugin:plugin-kubernetes-lib:1.0.1'
+    api 'io.kestra.plugin:plugin-kubernetes-lib:1.0.3-SNAPSHOT'
 }
 
 

--- a/src/main/java/io/kestra/plugin/kubernetes/AbstractPod.java
+++ b/src/main/java/io/kestra/plugin/kubernetes/AbstractPod.java
@@ -1,14 +1,11 @@
 package io.kestra.plugin.kubernetes;
 
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
-import java.nio.file.LinkOption;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.util.*;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.slf4j.Logger;
@@ -22,7 +19,6 @@ import io.kestra.plugin.kubernetes.shared.services.InstanceService;
 import io.kestra.plugin.kubernetes.shared.services.PodService;
 
 import io.fabric8.kubernetes.api.model.*;
-import io.fabric8.kubernetes.client.dsl.ContainerResource;
 import io.fabric8.kubernetes.client.dsl.PodResource;
 import io.fabric8.kubernetes.client.utils.KubernetesSerialization;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -32,7 +28,6 @@ import lombok.experimental.SuperBuilder;
 
 import static io.kestra.core.utils.Rethrow.throwConsumer;
 import static io.kestra.plugin.kubernetes.shared.services.PodService.withRetries;
-import static io.kestra.plugin.kubernetes.shared.services.PodService.withVerificationRetries;
 
 @SuperBuilder
 @ToString
@@ -47,8 +42,6 @@ public abstract class AbstractPod extends AbstractConnection {
     // Constants for marker files used in file transfer coordination
     protected static final String READY_MARKER = "ready";
     protected static final String ENDED_MARKER = "ended";
-
-    private static final Duration UPLOAD_VERIFICATION_TIMEOUT = Duration.ofSeconds(10);
 
     @Schema(
         title = "The namespace where the operation will be done",
@@ -147,193 +140,21 @@ public abstract class AbstractPod extends AbstractConnection {
         PodService.tempDir(runContext).toFile().mkdir();
     }
 
+    // OSS keys always resolve to regular files: PodCreate passes validatedInputFiles.keySet(), and
+    // PluginUtilsService.createInputFilesInternal materialises every key through a FileOutputStream
+    // (creating only parent dirs). So PodService.uploadInputFiles's per-file Files.isDirectory branch is
+    // a no-op for OSS input — only the grouped top-level name can be a directory, which the lib's bulk
+    // branch already handles. EE differs because it walks the working dir into a List<Path> that can
+    // itself contain directory entries.
     protected void uploadInputFiles(RunContext runContext, PodResource podResource, Logger logger, Set<String> inputFiles) throws IOException {
-        Path tempDir = PodService.tempDir(runContext);
-
-        Map<String, List<String>> grouped = inputFiles.stream()
-            .collect(Collectors.groupingBy(file ->
-            {
-                Path p = Path.of(file);
-                return p.getNameCount() > 0 ? p.getName(0).toString() : file;
-            }));
-
-        // Every fabric8 exec/upload call re-waits for the whole pod to report Ready before opening the
-        // connection — see PodOperationsImpl#getURL. That wait is structurally doomed to run to its full
-        // timeout here: the pod can't be Ready while init-files is itself still blocked waiting for the
-        // ready marker file, which is exactly the upload this call is about to perform. The caller already
-        // proved this container is Running via PodService.waitForInitContainerRunning() right before this
-        // call, so skip the redundant, unsatisfiable pod-Ready wait entirely instead of paying it on every
-        // retry attempt.
-        //
-        // Do NOT restore a positive timeout here. This value has already round-tripped once: it was set to
-        // 30s (bf45e73) to stop intermittent "exec endpoint not initialized yet" failures seen even while
-        // the pod was Running. That concern is real, but a pod-Ready wait cannot address it at THIS call
-        // site — the condition it waits on is unsatisfiable until after this very upload, so any positive
-        // value is dead time that expires and proceeds anyway, never protection. Transient exec-endpoint
-        // failures are covered instead by PodService.withRetries (5 attempts, 1s→10s backoff, 60s budget),
-        // which only became effective once each attempt stopped burning the full timeout first.
-        ContainerResource container = podResource
-            .inContainer(INIT_FILES_CONTAINER_NAME)
-            .withReadyWaitTimeout(0);
-
-        for (Map.Entry<String, List<String>> entry : grouped.entrySet()) {
-
-            String top = entry.getKey();
-            Path topAbsolute = tempDir.resolve(top);
-            String containerTop = "/kestra/working-dir/" + top;
-
-            boolean isBulkFallback = false;
-            if (Files.isDirectory(topAbsolute)) {
-                try {
-                    withRetries(
-                        logger, "uploadInputFilesBulk",
-                        () -> container
-                            .dir(containerTop)
-                            .upload(topAbsolute)
-                    );
-                    // A genuine truncation won't self-heal across retries — every attempt re-runs the same
-                    // count check to the same wrong number, burning the full backoff before falling back.
-                    // Retrying here anyway is intentional: it's the only thing that catches the transient
-                    // race where 'find' runs just before the tar extraction is fully visible on the pod.
-                    // Accepted tradeoff — correctness for the race case over shaving a few seconds off a
-                    // failure path that already falls back to a slower per-file re-upload regardless.
-                    withVerificationRetries(logger, "verifyDirectoryUpload", () -> verifyDirectoryUpload(container, logger, containerTop, topAbsolute));
-                    continue;
-                } catch (Exception e) {
-                    logger.info("Bulk upload failed for '{}', falling back to per-file upload. Reason: {}", top, e.getMessage());
-                    isBulkFallback = true;
-                }
-            }
-
-            // OSS keys always resolve to regular files here: PodCreate passes
-            // validatedInputFiles.keySet(), and PluginUtilsService.createInputFilesInternal materialises
-            // every key through a FileOutputStream (creating only parent dirs). Only the grouped top-level
-            // name can be a directory, which the bulk branch above already handles. EE differs because it
-            // walks the working dir into a List<Path> that can contain directory entries — do not "fix"
-            // this to match EE.
-            for (String file : entry.getValue()) {
-                String target = "/kestra/working-dir/" + file;
-                withRetries(
-                    logger, "uploadInputFiles",
-                    () ->
-                    {
-                        try (var fileInputStream = new FileInputStream(tempDir.resolve(file).toFile())) {
-                            return container
-                                .file(target)
-                                .upload(fileInputStream);
-                        }
-                    }
-                );
-
-                // Only cross-check per-file uploads when this is a fallback from a failed bulk-directory
-                // verification. Verifying every standalone top-level inputFile the same way would double
-                // pod round-trips on the common case (many unrelated individual inputFiles), for
-                // comparatively low risk since a single-file fabric8 upload is far less prone to silent
-                // truncation than the tar-based bulk-directory case.
-                if (isBulkFallback) {
-                    withVerificationRetries(logger, "verifyFileUpload", () -> verifyFileUpload(container, logger, target, tempDir.resolve(file)));
-                }
-            }
-        }
-
-        try {
-            PodService.uploadMarker(runContext, podResource, logger, READY_MARKER, INIT_FILES_CONTAINER_NAME);
-        } catch (IOException e) {
-            // The init container exits only when it finds /kestra/ready, so exit code 0 means
-            // the marker arrived even if the exec WebSocket closed before fabric8 got a clean result.
-            Pod current;
-            try {
-                current = podResource.get();
-            } catch (RuntimeException lookupError) {
-                // Status lookup failed too — surface the original upload error, not this one.
-                e.addSuppressed(lookupError);
-                throw e;
-            }
-            boolean initContainerSucceeded = current != null &&
-                current.getStatus() != null &&
-                current.getStatus().getInitContainerStatuses() != null &&
-                current.getStatus().getInitContainerStatuses().stream()
-                    .filter(cs -> INIT_FILES_CONTAINER_NAME.equals(cs.getName()))
-                    .anyMatch(
-                        cs -> cs.getState() != null &&
-                            cs.getState().getTerminated() != null &&
-                            Integer.valueOf(0).equals(cs.getState().getTerminated().getExitCode())
-                    );
-            if (initContainerSucceeded) {
-                logger.debug("uploadMarker exec failed but init container exited with code 0, marker was received");
-            } else {
-                throw e;
-            }
-        }
-    }
-
-    /**
-     * fabric8's directory upload can report success even when the tar transfer was truncated (e.g. a
-     * dependency directory silently missing files), so cross-check the actual file count on the pod.
-     *
-     * Both sides count non-directory entries. The pod side separates them with NUL rather than newline:
-     * a filename may legally contain a newline, and 'wc -l' would then count one entry several times and
-     * falsely flag a correct upload as truncated.
-     *
-     * This is a count-only check: a truncation that drops bytes from a file's content while keeping its
-     * entry (correct count, short file) is not caught here — only the single-file path ({@link
-     * #verifyFileUpload}) compares byte size.
-     */
-    private void verifyDirectoryUpload(ContainerResource container, Logger logger, String containerPath, Path localPath) throws IOException {
-        long expectedFileCount;
-        try (Stream<Path> files = Files.walk(localPath)) {
-            expectedFileCount = files.filter(path -> !Files.isDirectory(path, LinkOption.NOFOLLOW_LINKS)).count();
-        }
-
-        verifyUpload(
-            container, logger, containerPath, expectedFileCount, "file(s)",
-            "find " + shellQuote(containerPath) + " ! -type d -print0 | tr -dc '\\0' | wc -c"
+        PodService.uploadInputFiles(
+            runContext,
+            podResource,
+            logger,
+            PodService.tempDir(runContext),
+            Path.of("/kestra/working-dir"),
+            inputFiles.stream().map(Path::of).toList()
         );
-    }
-
-    /**
-     * Single-file counterpart of {@link #verifyDirectoryUpload}, comparing the uploaded file's size on
-     * the pod against the local file to catch a partial/corrupt transfer that fabric8 still reports as success.
-     */
-    private void verifyFileUpload(ContainerResource container, Logger logger, String containerPath, Path localFile) throws IOException {
-        verifyUpload(container, logger, containerPath, Files.size(localFile), "byte(s)", "wc -c < " + shellQuote(containerPath));
-    }
-
-    /**
-     * Single-quotes a value for safe interpolation into a `sh -c` command, escaping any embedded quote.
-     */
-    private static String shellQuote(String value) {
-        return "'" + value.replace("'", "'\\''") + "'";
-    }
-
-    /**
-     * Best-effort: if the sidecar image lacks 'find'/'wc', the check is skipped rather than failing the task.
-     */
-    private void verifyUpload(ContainerResource container, Logger logger, String containerPath, long expected, String unit, String shellCommand) throws IOException {
-        Optional<Long> actual = PodService.execOutput(container, logger, UPLOAD_VERIFICATION_TIMEOUT, "sh", "-c", shellCommand)
-            .map(String::trim)
-            .flatMap(AbstractPod::parseLong);
-
-        if (actual.isEmpty()) {
-            logger.debug("Skipping upload verification for '{}': the file-sidecar image does not support this check, or the verification command timed out", containerPath);
-            return;
-        }
-
-        // Only a shortfall means truncation — a transfer cannot add entries.
-        if (actual.get() < expected) {
-            throw new IOException(
-                "Upload verification failed for '" + containerPath + "': expected " + expected + " " + unit + " but found " +
-                    actual.get() + " in the file-sidecar container — the tar transfer was likely truncated"
-            );
-        }
-    }
-
-    private static Optional<Long> parseLong(String output) {
-        try {
-            return Optional.of(Long.parseLong(output));
-        } catch (NumberFormatException e) {
-            return Optional.empty();
-        }
     }
 
     protected Map<Path, Path> downloadOutputFiles(RunContext runContext, PodResource podResource, Logger logger, Map<String, Object> additionalVars, Duration retryMaxDuration)

--- a/src/test/java/io/kestra/plugin/kubernetes/AbstractPodTest.java
+++ b/src/test/java/io/kestra/plugin/kubernetes/AbstractPodTest.java
@@ -1,19 +1,12 @@
 package io.kestra.plugin.kubernetes;
 
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Timeout;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.slf4j.Logger;
@@ -30,15 +23,10 @@ import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodBuilder;
 import io.fabric8.kubernetes.client.dsl.ContainerResource;
 import io.fabric8.kubernetes.client.dsl.CopyOrReadable;
-import io.fabric8.kubernetes.client.dsl.ExecWatch;
 import io.fabric8.kubernetes.client.dsl.PodResource;
-import io.fabric8.kubernetes.client.dsl.TtyExecErrorable;
 import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
 import jakarta.inject.Inject;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -70,7 +58,7 @@ class AbstractPodTest {
         Mockito.when(container.file(Mockito.anyString()))
             .thenReturn(fileUploader);
 
-        Mockito.when(fileUploader.upload(Mockito.any(InputStream.class)))
+        Mockito.when(fileUploader.upload(Mockito.any(Path.class)))
             .thenReturn(true);
 
         RunContext runContext = runContextFactory.of(Map.of());
@@ -84,7 +72,9 @@ class AbstractPodTest {
 
         TestPod pod = new TestPod();
 
-        try (MockedStatic<PodService> staticMock = Mockito.mockStatic(PodService.class)) {
+        // This delegate now forwards to the real PodService.uploadInputFiles (see plugin-kubernetes-lib),
+        // so let unstubbed statics run for real and only intercept the ones this test needs to control.
+        try (MockedStatic<PodService> staticMock = Mockito.mockStatic(PodService.class, Mockito.CALLS_REAL_METHODS)) {
 
             staticMock.when(() -> PodService.tempDir(runContext)).thenReturn(temp);
 
@@ -92,21 +82,20 @@ class AbstractPodTest {
                 () -> PodService.uploadMarker(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.anyString(), Mockito.anyString())
             ).then(inv -> null);
 
-            staticMock.when(() -> PodService.withRetries(Mockito.any(), Mockito.anyString(), Mockito.any())).thenCallRealMethod();
-            // The 3-arg withRetries delegates to the 4-arg (Duration) overload, so it must run for real too.
-            staticMock.when(() -> PodService.withRetries(Mockito.any(), Mockito.anyString(), Mockito.any(), Mockito.any())).thenCallRealMethod();
-
             pod.uploadInputFiles(runContext, podResource, logger, inputFiles);
         }
 
         // Pins the fix for #329: init-files uploads must skip the pod-Ready wait, since the pod
         // structurally cannot become Ready while init-files itself is blocked on the ready marker.
-        Mockito.verify(container).withReadyWaitTimeout(0);
+        // atLeastOnce (not an exact count): PodService.uploadMarker also builds its own container chain
+        // through withReadyWaitTimeout(0), so the call count is an implementation detail — the value 0 is
+        // the guard, not how many times it's set.
+        Mockito.verify(container, Mockito.atLeastOnce()).withReadyWaitTimeout(0);
 
         Mockito.verify(container, Mockito.times(1)).file("/kestra/working-dir/a.txt");
         Mockito.verify(container, Mockito.times(1)).file("/kestra/working-dir/b.txt");
 
-        Mockito.verify(fileUploader, Mockito.times(2)).upload(Mockito.any(InputStream.class));
+        Mockito.verify(fileUploader, Mockito.times(2)).upload(Mockito.any(Path.class));
     }
 
     @Test
@@ -138,7 +127,9 @@ class AbstractPodTest {
         TestPod pod = new TestPod();
 
         // inputFiles is empty, so tempDir is computed but never dereferenced — no need to stub it.
-        try (MockedStatic<PodService> staticMock = Mockito.mockStatic(PodService.class)) {
+        // CALLS_REAL_METHODS: the delegate now forwards to the real PodService.uploadInputFiles, which
+        // must actually run (and reach uploadMarker) for this regression test to be meaningful.
+        try (MockedStatic<PodService> staticMock = Mockito.mockStatic(PodService.class, Mockito.CALLS_REAL_METHODS)) {
             staticMock.when(
                 () -> PodService.uploadMarker(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.anyString(), Mockito.anyString())
             ).thenThrow(new IOException("exec WebSocket closed before result"));
@@ -173,232 +164,14 @@ class AbstractPodTest {
         TestPod pod = new TestPod();
 
         // inputFiles is empty, so tempDir is computed but never dereferenced — no need to stub it.
-        try (MockedStatic<PodService> staticMock = Mockito.mockStatic(PodService.class)) {
+        // CALLS_REAL_METHODS: the delegate now forwards to the real PodService.uploadInputFiles, which
+        // must actually run (and reach uploadMarker) for this regression test to be meaningful.
+        try (MockedStatic<PodService> staticMock = Mockito.mockStatic(PodService.class, Mockito.CALLS_REAL_METHODS)) {
             staticMock.when(
                 () -> PodService.uploadMarker(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.anyString(), Mockito.anyString())
             ).thenThrow(new IOException("exec WebSocket closed before result"));
 
             assertThrows(IOException.class, () -> pod.uploadInputFiles(runContext, podResource, logger, Set.of()));
         }
-    }
-
-    @Timeout(value = 15, unit = TimeUnit.MINUTES)
-    @Test
-    void shouldFallBackToPerFileUploadWhenBulkVerificationDetectsTruncatedTransfer() throws Exception {
-        // Regression test: fabric8's dir().upload() can report success even when the tar transfer was
-        // truncated (e.g. a Python dependency directory silently missing files). Post-upload verification
-        // must catch the mismatch and fall back to re-uploading every file individually.
-        PodResource podResource = Mockito.mock(PodResource.class);
-        Logger logger = Mockito.mock(Logger.class);
-        ContainerResource container = Mockito.mock(ContainerResource.class);
-
-        Mockito.when(podResource.inContainer("init-files")).thenReturn(container);
-        // Both the raw upload and the verification-only exec (see PodService#execOutput) now pass a 0
-        // readyWaitTimeout and reuse this same container mock, so keep the lenient matcher here: the
-        // exact value is pinned by shouldUploadInputFiles instead.
-        Mockito.when(container.withReadyWaitTimeout(Mockito.any(Integer.class))).thenReturn(container);
-
-        CopyOrReadable dirUploader = Mockito.mock(CopyOrReadable.class);
-        Mockito.when(container.dir(Mockito.anyString())).thenReturn(dirUploader);
-        // fabric8 falsely reports success even though the transfer was truncated
-        Mockito.when(dirUploader.upload(Mockito.any(Path.class))).thenReturn(true);
-
-        CopyOrReadable fileUploader = Mockito.mock(CopyOrReadable.class);
-        Mockito.when(container.file(Mockito.anyString())).thenReturn(fileUploader);
-        Mockito.when(fileUploader.upload(Mockito.any(InputStream.class))).thenReturn(true);
-
-        // Simulate the verification exec: the directory file-count check reports only 1 file (truncated),
-        // while the per-file size checks that follow during the fallback report the correct byte counts.
-        Mockito.when(container.writingOutput(Mockito.any(OutputStream.class))).thenAnswer(writingOutputInvocation ->
-        {
-            OutputStream out = writingOutputInvocation.getArgument(0);
-            TtyExecErrorable errorable = Mockito.mock(TtyExecErrorable.class);
-            Mockito.when(errorable.exec(Mockito.any(String[].class))).thenAnswer(execInvocation ->
-            {
-                // Mockito expands varargs into individual arguments for InvocationOnMock, regardless of
-                // how the real call packed them, so read them via getArguments() rather than getArgument(0).
-                Object[] command = execInvocation.getArguments();
-                String shellCommand = (String) command[command.length - 1];
-                String response = shellCommand.contains("find")
-                    ? "1"
-                    : shellCommand.contains("pkg1.txt") ? "2" : "3";
-                out.write(response.getBytes(StandardCharsets.UTF_8));
-
-                ExecWatch watch = Mockito.mock(ExecWatch.class);
-                Mockito.when(watch.exitCode()).thenReturn(CompletableFuture.completedFuture(0));
-                return watch;
-            });
-            return errorable;
-        });
-
-        RunContext runContext = runContextFactory.of(Map.of());
-        Path temp = PodService.tempDir(runContext);
-
-        Files.createDirectories(temp.resolve("deps"));
-        Files.writeString(temp.resolve("deps/pkg1.txt"), "AA");
-        Files.writeString(temp.resolve("deps/pkg2.txt"), "BBB");
-
-        Set<String> inputFiles = Set.of("deps/pkg1.txt", "deps/pkg2.txt");
-
-        TestPod pod = new TestPod();
-
-        try (var staticMock = Mockito.mockStatic(PodService.class, Mockito.CALLS_REAL_METHODS)) {
-            staticMock.when(() -> PodService.tempDir(runContext)).thenReturn(temp);
-            staticMock.when(
-                () -> PodService.uploadMarker(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.anyString(), Mockito.anyString())
-            ).thenAnswer(inv -> null);
-
-            pod.uploadInputFiles(runContext, podResource, logger, inputFiles);
-        }
-
-        // Bulk directory upload was attempted first...
-        Mockito.verify(container, Mockito.times(1)).dir("/kestra/working-dir/deps");
-        Mockito.verify(dirUploader, Mockito.times(1)).upload(temp.resolve("deps"));
-
-        // ...but verification detected the truncated transfer, so every file was re-uploaded individually.
-        Mockito.verify(container, Mockito.times(1)).file("/kestra/working-dir/deps/pkg1.txt");
-        Mockito.verify(container, Mockito.times(1)).file("/kestra/working-dir/deps/pkg2.txt");
-        Mockito.verify(fileUploader, Mockito.times(2)).upload(Mockito.any(InputStream.class));
-    }
-
-    @Timeout(value = 15, unit = TimeUnit.MINUTES)
-    @Test
-    void shouldAcceptBulkUploadWhenVerificationCountsMatch() throws Exception {
-        // Happy-path companion to shouldFallBackToPerFileUploadWhenBulkVerificationDetectsTruncatedTransfer:
-        // the pod-side file count matches the local directory, so verification passes and no per-file
-        // fallback upload happens.
-        PodResource podResource = Mockito.mock(PodResource.class);
-        Logger logger = Mockito.mock(Logger.class);
-        ContainerResource container = Mockito.mock(ContainerResource.class);
-
-        Mockito.when(podResource.inContainer("init-files")).thenReturn(container);
-        // Both the raw upload and the verification-only exec (see PodService#execOutput) now pass a 0
-        // readyWaitTimeout and reuse this same container mock, so keep the lenient matcher here: the
-        // exact value is pinned by shouldUploadInputFiles instead.
-        Mockito.when(container.withReadyWaitTimeout(Mockito.any(Integer.class))).thenReturn(container);
-
-        CopyOrReadable dirUploader = Mockito.mock(CopyOrReadable.class);
-        Mockito.when(container.dir(Mockito.anyString())).thenReturn(dirUploader);
-        Mockito.when(dirUploader.upload(Mockito.any(Path.class))).thenReturn(true);
-
-        CopyOrReadable fileUploader = Mockito.mock(CopyOrReadable.class);
-        Mockito.when(container.file(Mockito.anyString())).thenReturn(fileUploader);
-        Mockito.when(fileUploader.upload(Mockito.any(InputStream.class))).thenReturn(true);
-
-        // Realistic verification exec: the pod-side file count matches the two files uploaded locally.
-        Mockito.when(container.writingOutput(Mockito.any(OutputStream.class))).thenAnswer(writingOutputInvocation ->
-        {
-            OutputStream out = writingOutputInvocation.getArgument(0);
-            TtyExecErrorable errorable = Mockito.mock(TtyExecErrorable.class);
-            Mockito.when(errorable.exec(Mockito.any(String[].class))).thenAnswer(execInvocation ->
-            {
-                out.write("2".getBytes(StandardCharsets.UTF_8));
-
-                ExecWatch watch = Mockito.mock(ExecWatch.class);
-                Mockito.when(watch.exitCode()).thenReturn(CompletableFuture.completedFuture(0));
-                return watch;
-            });
-            return errorable;
-        });
-
-        RunContext runContext = runContextFactory.of(Map.of());
-        Path temp = PodService.tempDir(runContext);
-
-        Files.createDirectories(temp.resolve("deps"));
-        Files.writeString(temp.resolve("deps/pkg1.txt"), "AA");
-        Files.writeString(temp.resolve("deps/pkg2.txt"), "BBB");
-
-        Set<String> inputFiles = Set.of("deps/pkg1.txt", "deps/pkg2.txt");
-
-        TestPod pod = new TestPod();
-
-        try (var staticMock = Mockito.mockStatic(PodService.class, Mockito.CALLS_REAL_METHODS)) {
-            staticMock.when(() -> PodService.tempDir(runContext)).thenReturn(temp);
-            staticMock.when(
-                () -> PodService.uploadMarker(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.anyString(), Mockito.anyString())
-            ).thenAnswer(inv -> null);
-
-            pod.uploadInputFiles(runContext, podResource, logger, inputFiles);
-        }
-
-        // Bulk directory upload was attempted, and the verification exec actually ran...
-        Mockito.verify(container, Mockito.times(1)).dir("/kestra/working-dir/deps");
-        Mockito.verify(dirUploader, Mockito.times(1)).upload(temp.resolve("deps"));
-        Mockito.verify(container, Mockito.atLeastOnce()).writingOutput(Mockito.any(OutputStream.class));
-
-        // ...counts matched, so no per-file fallback upload was needed.
-        Mockito.verify(container, Mockito.never()).file(Mockito.anyString());
-    }
-
-    @Timeout(value = 15, unit = TimeUnit.MINUTES)
-    @Test
-    void shouldAcceptBulkUploadWhenPodReportsMoreEntriesThanExpected() throws Exception {
-        // Regression test: a filename containing a newline used to make the pod-side 'find | wc -l' count
-        // one file several times, so the check reported a truncated transfer on a perfectly good upload.
-        PodResource podResource = Mockito.mock(PodResource.class);
-        Logger logger = Mockito.mock(Logger.class);
-        ContainerResource container = Mockito.mock(ContainerResource.class);
-
-        Mockito.when(podResource.inContainer("init-files")).thenReturn(container);
-        Mockito.when(container.withReadyWaitTimeout(Mockito.any(Integer.class))).thenReturn(container);
-
-        CopyOrReadable dirUploader = Mockito.mock(CopyOrReadable.class);
-        Mockito.when(container.dir(Mockito.anyString())).thenReturn(dirUploader);
-        Mockito.when(dirUploader.upload(Mockito.any(Path.class))).thenReturn(true);
-
-        CopyOrReadable fileUploader = Mockito.mock(CopyOrReadable.class);
-        Mockito.when(container.file(Mockito.anyString())).thenReturn(fileUploader);
-        Mockito.when(fileUploader.upload(Mockito.any(InputStream.class))).thenReturn(true);
-
-        AtomicReference<String> directoryCheck = new AtomicReference<>();
-
-        // Two files locally, but the pod reports six — the shape a line-counting check produced.
-        Mockito.when(container.writingOutput(Mockito.any(OutputStream.class))).thenAnswer(writingOutputInvocation ->
-        {
-            OutputStream out = writingOutputInvocation.getArgument(0);
-            TtyExecErrorable errorable = Mockito.mock(TtyExecErrorable.class);
-            Mockito.when(errorable.exec(Mockito.any(String[].class))).thenAnswer(execInvocation ->
-            {
-                Object[] command = execInvocation.getArguments();
-                String shellCommand = (String) command[command.length - 1];
-                if (shellCommand.contains("find")) {
-                    directoryCheck.set(shellCommand);
-                }
-                out.write("6".getBytes(StandardCharsets.UTF_8));
-
-                ExecWatch watch = Mockito.mock(ExecWatch.class);
-                Mockito.when(watch.exitCode()).thenReturn(CompletableFuture.completedFuture(0));
-                return watch;
-            });
-            return errorable;
-        });
-
-        RunContext runContext = runContextFactory.of(Map.of());
-        Path temp = PodService.tempDir(runContext);
-
-        Files.createDirectories(temp.resolve("deps"));
-        Files.writeString(temp.resolve("deps/pkg1.txt"), "AA");
-        Files.writeString(temp.resolve("deps/\n\n--- Changes ---\n\n"), "BBB");
-
-        Set<String> inputFiles = Set.of("deps/pkg1.txt", "deps/\n\n--- Changes ---\n\n");
-
-        TestPod pod = new TestPod();
-
-        try (var staticMock = Mockito.mockStatic(PodService.class, Mockito.CALLS_REAL_METHODS)) {
-            staticMock.when(() -> PodService.tempDir(runContext)).thenReturn(temp);
-            staticMock.when(
-                () -> PodService.uploadMarker(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.anyString(), Mockito.anyString())
-            ).thenAnswer(inv -> null);
-
-            pod.uploadInputFiles(runContext, podResource, logger, inputFiles);
-        }
-
-        // An excess count is not a truncation, so the bulk upload stands and nothing is re-uploaded.
-        Mockito.verify(dirUploader, Mockito.times(1)).upload(temp.resolve("deps"));
-        Mockito.verify(container, Mockito.never()).file(Mockito.anyString());
-
-        // The count itself must be NUL-separated, otherwise a newline in a filename inflates it.
-        assertThat(directoryCheck.get(), containsString("-print0"));
-        assertThat(directoryCheck.get(), not(containsString("wc -l")));
     }
 }


### PR DESCRIPTION
## Summary

- Rewires `AbstractPod.uploadInputFiles` to delegate to the shared `PodService.uploadInputFiles(RunContext, PodResource, Logger, Path localBaseDir, Path containerWorkingDir, List<Path> relativePaths)` added to `plugin-kubernetes-lib` in Step A ([lib PR #17](https://github.com/kestra-io/plugin-kubernetes-lib/pull/17)).
- Deletes the now-duplicated implementation from `AbstractPod.java`: the body of `uploadInputFiles`, `verifyDirectoryUpload`, `verifyFileUpload`, `verifyUpload`, `shellQuote`, `parseLong`, and the `UPLOAD_VERIFICATION_TIMEOUT` constant, plus the imports that became unused (`FileInputStream`, `LinkOption`, `Collectors`, `ContainerResource`, `withVerificationRetries`).
- Keeps a thin `protected` delegate on `AbstractPod` that only adapts `Set<String>` → `List<Path>` and forwards to the lib method. This preserves the OSS `Set<String>` call-site seam on `PodCreate` (no change needed there) and keeps the `#334` `withReadyWaitTimeout(0)` pinning regression test living in `AbstractPodTest`, per the issue's acceptance criteria.
- Trims `AbstractPodTest`: removed the bulk-count-match / truncation-fallback tests that are now pure duplicates of the lib's own `PodServiceUploadInputFilesTest` (ported in Step A). Kept `shouldUploadInputFiles` (with the `#334` pinning assertion, now `atLeastOnce()` since `PodService.uploadMarker` also builds its own `withReadyWaitTimeout(0)` container chain — the guard is on the value `0`, not the call count) and the marker-guard pair `shouldTolerateMarkerUploadFailureWhenInitContainerSucceeded` / `shouldPropagateMarkerUploadFailureWhenInitContainerDidNotSucceed`.
- Bumps `build.gradle` to `io.kestra.plugin:plugin-kubernetes-lib:1.0.3-SNAPSHOT` for local testing against `mavenLocal()`. **This is temporary** — it flips to the released `1.0.3` at Step D before merge.

No behaviour change: the `withReadyWaitTimeout(0)` value and retry/verification semantics are unchanged — only the code that implements them moved to the shared lib.

part-of: https://github.com/kestra-io/plugin-kubernetes/issues/335

### CI caveat

GitHub CI on this PR will likely be **red** because `plugin-kubernetes-lib:1.0.3-SNAPSHOT` is only published to local `mavenLocal()`, not to a remote repository yet. This is expected and resolves at Step D once the lib's `1.0.3` release is cut and this pin flips from `1.0.3-SNAPSHOT` to `1.0.3`. Do not attempt to fix CI by publishing the snapshot remotely or reverting the version pin — local Gradle `test` and `shadowJar` passing is the gate for this PR.

## Test plan

- [x] `rtk test ./gradlew test` passes locally against the mavenLocal `1.0.3-SNAPSHOT`
- [x] `./gradlew shadowJar` builds
- [x] Grepped `src/` for `verifyDirectoryUpload`, `verifyFileUpload`, `verifyUpload`, `shellQuote`, `parseLong`, `UPLOAD_VERIFICATION_TIMEOUT` — no references remain outside the lib

---
*[View as Artifact](https://claude.ai/code/artifact/19c10c87-a0c1-4c1a-9b43-87fecaf4b5e4)*